### PR TITLE
[codex] Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches-ignore:
+      - master
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Run tests
+        run: npm test


### PR DESCRIPTION
## Summary
Add a GitHub Actions CI workflow for pull requests targeting master and for non-master branch pushes.

## Why
Dependabot PRs were opening without automated build/test validation because the repository did not have a CI workflow committed on master.

## Validation
- npm ci
- npm run build
- npm test