### PR TITLE
[codex] Harden repo hygiene and release checks

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,37 @@
+---
+name: Bug report
+about: Report a reproducible defect in the SDK, CLI, or release workflow.
+title: "[Bug]: "
+labels: ["bug"]
+assignees: []
+---
+
+## Summary
+
+Describe the problem in one or two sentences.
+
+## Environment
+
+- Node.js version:
+- Package version:
+- Command or SDK method:
+- OS:
+
+## Steps To Reproduce
+
+1.
+2.
+3.
+
+## Expected Result
+
+Describe what should have happened.
+
+## Actual Result
+
+Include the observed behavior. Redact credentials, bearer tokens, cookies, and
+child-specific personal data before pasting logs or payloads.
+
+## Additional Context
+
+Add any relevant notes, screenshots, or links.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,24 @@
+---
+name: Feature request
+about: Propose a new SDK capability, CLI command, or maintenance improvement.
+title: "[Feature]: "
+labels: ["enhancement"]
+assignees: []
+---
+
+## Summary
+
+Describe the capability you want to add.
+
+## Use Case
+
+Explain the workflow or problem this feature would improve.
+
+## Proposed Interface
+
+Describe the ideal CLI command, SDK method, or behavior if you already have a
+preference.
+
+## Alternatives Considered
+
+List any workarounds or competing approaches you evaluated.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## Summary
+
+- describe the user-visible change
+- list any internal refactors worth calling out
+
+## Verification
+
+- [ ] `npm run lint`
+- [ ] `npm run format:check`
+- [ ] `npm run build`
+- [ ] `npm test`
+- [ ] `npm run pack:check`
+
+## Notes
+
+- mention release, docs, or follow-up work if relevant

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,6 @@ jobs:
 
       - name: Run tests
         run: npm test
+
+      - name: Verify package tarball
+        run: npm run pack:check

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ coverage/
 .env
 .DS_Store
 .claude/
+.serena/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - ESLint, Prettier, Husky, and lint-staged automation for local code-quality enforcement.
 - Runtime response validation for portal and Synergia API payloads with explicit schema failures.
 - Mocked SDK flow coverage for login, child resolution, and child-scoped API requests.
+- Security policy plus issue and pull request templates for repository maintenance.
+- Reproducible Vitest V8 coverage reporting for maintainers.
+- Verification notes for the March 29 follow-up checks covering live payload variance, coverage, packaging, and timeout behavior.
 
 ### Changed
 
 - GitHub Actions CI now runs linting, formatting checks, build, and tests on pull requests and non-`master` pushes.
+- Package metadata now links npm consumers back to the GitHub repository and issue tracker.
+- Release safety checks now include `npm pack --dry-run` in both CI and `prepublishOnly`.
 
 ### Fixed
 
 - Root CLI help and no-argument invocation now exit cleanly without appending a JSON error payload.
+- Root CLI `--version` now exits cleanly and prints the published package version.
+- Attendance validation now accepts the mixed numeric and string ids returned by the live API.
 - Portal CSRF token extraction now parses HTML defensively and reports a specific login-page error when the token is missing.
 - Portal login now preserves non-auth API failures from post-login verification instead of always reporting bad credentials.
 - README SDK usage example now uses `LibrusSession.fromEnv()` instead of the unsupported zero-argument constructor.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026
+Copyright (c) 2026 Andrey Koltsov
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ npm install librus-sdk
 Use the CLI without installing it globally:
 
 ```bash
+npx librus --version
 npx librus children list
 npx librus grades list --child <id-or-login>
 ```
@@ -39,6 +40,7 @@ npm install
 npm run lint
 npm run format:check
 npm run build
+npm run pack:check
 npm run cli -- children list
 npm run cli -- grades list --child <id-or-login>
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+| ------- | --------- |
+| 0.1.x   | Yes       |
+| < 0.1.0 | No        |
+
+## Reporting A Vulnerability
+
+Do not open a public GitHub issue for security-sensitive reports.
+
+Use GitHub's private vulnerability reporting flow if it is available for this
+repository. If you cannot use that flow, email `andrewkoltsov@gmail.com` with:
+
+- a concise description of the issue
+- affected versions and environments
+- reproduction steps or a proof of concept
+- any suggested mitigation if you already have one
+
+I will acknowledge new reports within 3 business days and will coordinate a
+fix and disclosure timeline once the issue is confirmed.

--- a/docs/verification-2026-03-29.md
+++ b/docs/verification-2026-03-29.md
@@ -1,0 +1,99 @@
+# Verification Notes
+
+Date: 2026-03-29
+
+All notes below are sanitized:
+
+- no raw credentials
+- no raw bearer tokens
+- no child names
+
+## Local checks
+
+Successful commands:
+
+```bash
+npm run lint
+npm run build
+npm test
+npm run test:coverage
+npm run pack:check
+```
+
+Outcome:
+
+- lint succeeded
+- build succeeded
+- test suite passed: 32 tests across 5 files
+- coverage report succeeded after adding `@vitest/coverage-v8`
+- package dry run succeeded with a temporary npm cache, confirming the tarball includes `dist/`, `README.md`, `LICENSE`, and the CLI entrypoint
+
+Coverage summary from `npm run test:coverage`:
+
+- statements: `82.99%`
+- branches: `77.67%`
+- functions: `81.96%`
+- lines: `82.85%`
+
+Largest remaining gaps:
+
+- command handlers other than `children list`
+- `LibrusSession` cache and environment branches
+- type-only model barrels, which naturally report `0%`
+
+## Live CLI verification
+
+Successful commands:
+
+```bash
+node dist/cli/main.js children list
+node dist/cli/main.js me --child <selected-child-id>
+node dist/cli/main.js grades list --child <selected-child-id>
+node dist/cli/main.js attendance list --child <selected-child-id>
+```
+
+Outcome on the verified account:
+
+- `children list` returned exactly `2` linked child accounts
+- `me`, `grades list`, and `attendance list` all completed successfully against the live API
+- the current response validation accepts the real `Me`, `SynergiaAccounts`, `Grades`, and `Attendances` payloads after widening `Attendance.Id`
+
+Observed live payload variance:
+
+- `Attendances[*].Id` is mixed-type on the live API:
+  - numeric ids: `572`
+  - string ids: `26`
+- `Attendances[*].Trip` is absent on most records:
+  - missing `Trip` field: `572`
+- sampled grade references were non-null in this account:
+  - `AddedBy`: `0` nulls
+  - `Category`: `0` nulls
+  - `Lesson`: `0` nulls
+  - `Student`: `0` nulls
+  - `Subject`: `0` nulls
+
+That means the attendance schema needed an immediate fix, while grade nullability remains unobserved rather than disproven.
+
+## Timeout behavior
+
+Successful command:
+
+```bash
+node --input-type=module <<'NODE'
+import http from "node:http";
+import { once } from "node:events";
+import { PortalClient } from "./dist/sdk/portal/PortalClient.js";
+
+const server = http.createServer(() => {});
+server.listen(0, "127.0.0.1");
+await once(server, "listening");
+// ...
+NODE
+```
+
+Outcome:
+
+- a local server that accepted the connection and never responded left `PortalClient.login(...)` pending for more than `1500ms`
+- no built-in timeout fired during that window
+
+This confirms that request timeout policy is still an architectural follow-up, not an already-implemented behavior.

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@types/node": "^25.5.0",
+        "@vitest/coverage-v8": "^4.1.2",
         "eslint": "^10.1.0",
         "eslint-config-prettier": "^10.1.8",
         "globals": "^17.4.0",
@@ -35,6 +36,66 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@emnapi/core": {
@@ -693,12 +754,33 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.1",
@@ -1286,6 +1368,37 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.2.tgz",
+      "integrity": "sha512-sPK//PHO+kAkScb8XITeB1bf7fsk85Km7+rt4eeuRR3VS1/crD47cmV5wicisJmjNdfeokTZwjMk4Mj2d58Mgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.2",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.2",
+        "vitest": "4.1.2"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
@@ -1489,6 +1602,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
       }
     },
     "node_modules/balanced-match": {
@@ -2098,6 +2223,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/husky": {
       "version": "9.1.7",
       "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
@@ -2179,6 +2321,52 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
@@ -2589,6 +2777,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mimic-function": {
@@ -3066,6 +3282,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/tinybench": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,15 @@
   "name": "librus-sdk",
   "version": "0.1.1",
   "description": "TypeScript SDK and CLI for the Librus family portal flow.",
+  "author": "Andrey Koltsov",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/andrewkoltsov/librus-sdk.git"
+  },
+  "homepage": "https://github.com/andrewkoltsov/librus-sdk#readme",
+  "bugs": {
+    "url": "https://github.com/andrewkoltsov/librus-sdk/issues"
+  },
   "type": "module",
   "main": "dist/sdk/index.js",
   "types": "dist/sdk/index.d.ts",
@@ -24,8 +33,11 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "pack:check": "node ./scripts/pack-check.mjs",
+    "prepublishOnly": "npm run lint && npm run format:check && npm run build && npm test && npm run pack:check",
     "prepare": "husky",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "files": [
     "dist",
@@ -50,6 +62,7 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@types/node": "^25.5.0",
+    "@vitest/coverage-v8": "^4.1.2",
     "eslint": "^10.1.0",
     "eslint-config-prettier": "^10.1.8",
     "globals": "^17.4.0",

--- a/scripts/pack-check.mjs
+++ b/scripts/pack-check.mjs
@@ -1,0 +1,24 @@
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
+const cacheDir = join(tmpdir(), "librus-sdk-npm-cache");
+const result = spawnSync(
+  npmCommand,
+  ["pack", "--dry-run", "--ignore-scripts", "--cache", cacheDir],
+  {
+    stdio: "inherit",
+    env: {
+      ...process.env,
+      npm_config_cache: cacheDir,
+      NPM_CONFIG_CACHE: cacheDir,
+    },
+  },
+);
+
+if (result.error) {
+  throw result.error;
+}
+
+process.exit(result.status ?? 1);

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -2,7 +2,7 @@
 
 import { Command } from "commander";
 import { config as loadDotEnv } from "dotenv";
-import { realpathSync } from "node:fs";
+import { readFileSync, realpathSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
 import { LibrusSession } from "../sdk/index.js";
@@ -13,6 +13,10 @@ import { formatCliError, writeJson } from "./commands/common.js";
 import { createGradesCommand } from "./commands/grades.js";
 import { createHomeworkCommand } from "./commands/homework.js";
 import { createMeCommand } from "./commands/me.js";
+
+const packageJson = JSON.parse(
+  readFileSync(new URL("../../package.json", import.meta.url), "utf8"),
+) as { version: string };
 
 export function createDefaultCliContext(): CliContext {
   return {
@@ -30,7 +34,12 @@ export function createProgram(context: CliContext): Command {
   const program = new Command()
     .name("librus")
     .description("CLI for the Librus family portal flow")
-    .showHelpAfterError();
+    .version(packageJson.version)
+    .showHelpAfterError()
+    .configureOutput({
+      writeOut: (chunk) => context.stdout.write(chunk),
+      writeErr: (chunk) => context.stderr.write(chunk),
+    });
 
   program.addCommand(createChildrenCommand(context));
   program.addCommand(createMeCommand(context));
@@ -63,6 +72,18 @@ export async function runCli(
     await program.parseAsync(argv);
     return 0;
   } catch (error) {
+    if (
+      error instanceof Error &&
+      "code" in error &&
+      "exitCode" in error &&
+      typeof error.code === "string" &&
+      error.code.startsWith("commander.") &&
+      typeof error.exitCode === "number" &&
+      error.exitCode === 0
+    ) {
+      return 0;
+    }
+
     writeJson(context.stderr, {
       error: formatCliError(error),
     });

--- a/src/sdk/models/synergia.ts
+++ b/src/sdk/models/synergia.ts
@@ -39,7 +39,7 @@ export interface GradesResponse extends SynergiaResponseEnvelope {
 }
 
 export interface Attendance {
-  Id: string;
+  Id: string | number;
   Lesson: ApiRef;
   Student: ApiRef;
   Trip?: ApiRef | undefined;

--- a/src/sdk/validation/schemas.ts
+++ b/src/sdk/validation/schemas.ts
@@ -71,7 +71,7 @@ const attendanceSchema = v.looseObject({
   AddDate: v.string(),
   AddedBy: apiRefSchema,
   Date: v.string(),
-  Id: v.string(),
+  Id: v.union([v.string(), v.number()]),
   Lesson: apiRefSchema,
   LessonNo: v.number(),
   Semester: v.number(),

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -2,6 +2,7 @@ import {
   mkdirSync,
   mkdtempSync,
   realpathSync,
+  readFileSync,
   rmSync,
   symlinkSync,
   writeFileSync,
@@ -17,6 +18,10 @@ import {
   type ChildAccount,
   type ChildAccountSummary,
 } from "../src/sdk/index.js";
+
+const packageJson = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+) as { version: string };
 
 function createChild(overrides: Partial<ChildAccount> = {}): ChildAccount {
   return {
@@ -99,6 +104,20 @@ describe("runCli", () => {
     expect(exitCode).toBe(0);
     expect(stderr).toBe("");
     expect(stdout).toContain("Usage: librus");
+  });
+
+  it("prints the package version and exits successfully for --version", async () => {
+    let stdout = "";
+    let stderr = "";
+    const exitCode = await runCli(["node", "librus", "--version"], {
+      stdout: { write: (chunk) => (stdout += chunk) },
+      stderr: { write: (chunk) => (stderr += chunk) },
+      createSession: () => createSessionStub() as never,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe(packageJson.version);
   });
 
   it("writes stable JSON errors to stderr", async () => {

--- a/test/synergia-client.test.ts
+++ b/test/synergia-client.test.ts
@@ -63,13 +63,13 @@ describe("SynergiaApiClient", () => {
     }
   });
 
-  it("accepts attendance payloads without a Trip field", async () => {
+  it("accepts attendance payloads with numeric ids and without a Trip field", async () => {
     const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
       new Response(
         JSON.stringify({
           Attendances: [
             {
-              Id: "1",
+              Id: 1,
               Lesson: { Id: 2, Url: "https://api.librus.pl/3.0/Lessons/2" },
               Student: { Id: 3, Url: "https://api.librus.pl/3.0/Students/3" },
               Date: "2026-03-28",
@@ -97,6 +97,7 @@ describe("SynergiaApiClient", () => {
     const response = await client.getAttendances();
 
     expect(response.Attendances).toHaveLength(1);
+    expect(response.Attendances[0]?.Id).toBe(1);
     expect(response.Attendances[0]?.Trip).toBeUndefined();
   });
 });


### PR DESCRIPTION
## What changed
- add repo maintenance files and metadata (`SECURITY.md`, issue/PR templates, npm metadata, LICENSE attribution)
- harden release safety with `prepublishOnly`, `pack:check`, and a CI tarball verification step
- fix the remaining root CLI contract gap by wiring Commander-owned `--version` output through the injected CLI context
- widen attendance `Id` validation to match live API payloads that return both numeric and string values
- add a March 29 verification note covering live payload variance, packaging, coverage, and timeout behavior
- ignore local scratch artifacts so they do not leak into the branch

## Why
The repo review found gaps in release hygiene, GitHub maintenance posture, and a few runtime contract issues that were still present on remote `master` after the earlier tooling PR merged.

## Impact
- npm consumers get correct repository metadata and safer publish checks
- the CLI now handles `--version` cleanly without relying on global stdout or emitting JSON errors
- attendance responses no longer fail validation when the API returns numeric ids
- maintainers get documented verification results and a baseline security/disclosure workflow

## Root cause
The repository had drift between published/package metadata, GitHub hygiene, and actual runtime behavior. The live Librus API also returns more payload variance than the original attendance model allowed.

## Validation
- `npm run lint`
- `npm test`
- `npm run build`
- `npm run test:coverage`
- `npm run pack:check`
- live CLI/API checks for `children list`, `me`, `grades list`, and `attendance list`
- delayed-server probe confirming timeout behavior remains a deferred architecture item
