### PR TITLE
[codex] Release 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-03-29
+
 ### Added
 
 - ESLint, Prettier, Husky, and lint-staged automation for local code-quality enforcement.
@@ -20,7 +22,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - GitHub Actions CI now runs the shared validation gates on pull requests and `master` pushes.
 - Releases now publish from `vX.Y.Z` tags with npm trusted publishing and changelog-backed GitHub Release notes.
-- GitHub Actions CI now runs the shared validation gates on pull requests and `master` pushes.
 - Package metadata now links npm consumers back to the GitHub repository and issue tracker.
 - Release safety checks now include `npm pack --dry-run` in both CI and `prepublishOnly`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "librus-sdk",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "librus-sdk",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librus-sdk",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "TypeScript SDK and CLI for the Librus family portal flow.",
   "author": "Andrey Koltsov",
   "repository": {


### PR DESCRIPTION
## Summary

Prepare the `0.2.0` minor release.

This PR:
- bumps the package version from `0.1.1` to `0.2.0`
- promotes the current `Unreleased` notes into a dated `0.2.0` changelog entry
- leaves a fresh `Unreleased` section for follow-up work
- removes a duplicated changelog bullet while cutting the release

No runtime code changes are introduced here; this is the release-preparation step for work that has already landed on `master`.

## Why

We have accumulated enough shipped work since `0.1.1` to cut the next minor release and prepare the repository for the tag-driven publish flow.

## Impact

After this PR is merged, the repository will be ready for tagging `v0.2.0` from `master` to trigger the release workflow.

## Validation

- `npm run validate`
