### PR TITLE
[codex] fix homework lesson number validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Homework validation now accepts mixed and null `HomeWork.LessonNo` values returned by the live API.
+
 ## [0.2.0] - 2026-03-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ npm run cli -- attendance list --child <id-or-login>
 npm run cli -- homework list --child <id-or-login>
 ```
 
+`HomeWork.LessonNo` mirrors the live Librus payload and may be `string`, `number`, or `null`.
+
 ## SDK usage
 
 ```ts
@@ -66,5 +68,7 @@ const session = LibrusSession.fromEnv();
 const children = await session.listChildren();
 console.log(children);
 ```
+
+`await session.forChild(child).getHomeWorks()` preserves the API's `HomeWork.LessonNo` value as `string`, `number`, or `null`.
 
 All commands write JSON to stdout by default. Errors are written as JSON to stderr and return a non-zero exit code.

--- a/src/sdk/models/synergia.ts
+++ b/src/sdk/models/synergia.ts
@@ -63,7 +63,7 @@ export interface HomeWork {
   CreatedBy: JsonObject | ApiRef | null;
   Date: string;
   Id: number;
-  LessonNo: number;
+  LessonNo: string | number | null;
   Subject: JsonObject | ApiRef | null;
   TimeFrom: string | null;
   TimeTo: string | null;

--- a/src/sdk/validation/schemas.ts
+++ b/src/sdk/validation/schemas.ts
@@ -95,7 +95,7 @@ const homeWorkSchema = v.looseObject({
   CreatedBy: v.union([apiRefOrJsonSchema, v.null()]),
   Date: v.string(),
   Id: v.number(),
-  LessonNo: v.number(),
+  LessonNo: v.union([v.string(), v.number(), v.null()]),
   Subject: v.union([apiRefOrJsonSchema, v.null()]),
   TimeFrom: v.union([v.string(), v.null()]),
   TimeTo: v.union([v.string(), v.null()]),

--- a/test/synergia-client.test.ts
+++ b/test/synergia-client.test.ts
@@ -116,4 +116,74 @@ describe("SynergiaApiClient", () => {
     expect(response.Attendances[1]?.Id).toBe("2");
     expect(response.Attendances[1]?.Trip).toBeUndefined();
   });
+
+  it("accepts homework payloads with string, numeric, or null lesson numbers", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          HomeWorks: [
+            {
+              AddDate: "2026-03-29 08:00:00",
+              Category: null,
+              Class: null,
+              Content: "Read chapter 5",
+              CreatedBy: null,
+              Date: "2026-03-29",
+              Id: 1,
+              LessonNo: "5",
+              Subject: {
+                Id: 10,
+                Url: "https://api.librus.pl/3.0/Subjects/10",
+              },
+              TimeFrom: null,
+              TimeTo: null,
+            },
+            {
+              AddDate: "2026-03-30 08:00:00",
+              Category: null,
+              Class: null,
+              Content: "Solve exercises 1-3",
+              CreatedBy: null,
+              Date: "2026-03-30",
+              Id: 2,
+              LessonNo: 2,
+              Subject: {
+                Id: 11,
+                Url: "https://api.librus.pl/3.0/Subjects/11",
+              },
+              TimeFrom: "09:00",
+              TimeTo: "09:45",
+            },
+            {
+              AddDate: "2026-03-31 08:00:00",
+              Category: null,
+              Class: null,
+              Content: "Bring materials",
+              CreatedBy: null,
+              Date: "2026-03-31",
+              Id: 3,
+              LessonNo: null,
+              Subject: null,
+              TimeFrom: null,
+              TimeTo: null,
+            },
+          ],
+          Resources: {},
+          Url: "https://api.librus.pl/3.0/HomeWorks",
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      ),
+    );
+
+    const client = new SynergiaApiClient("token", { fetch: fetchMock });
+    const response = await client.getHomeWorks();
+
+    expect(response.HomeWorks).toHaveLength(3);
+    expect(response.HomeWorks[0]?.LessonNo).toBe("5");
+    expect(response.HomeWorks[1]?.LessonNo).toBe(2);
+    expect(response.HomeWorks[2]?.LessonNo).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- widen `HomeWork.LessonNo` validation to accept `string`, `number`, and `null`
- align the exported `HomeWork` SDK type with the live API payload shape
- add a regression test for `getHomeWorks()` and document the wire-shape behavior in the README and changelog

## Why
`librus-sdk@0.2.0` rejected real `/HomeWorks` responses because the runtime schema and public type assumed `LessonNo` was always a number.

## Impact
This unblocks both `npx librus homework list --child <id>` and `await session.forChild(child).getHomeWorks()` for accounts where Librus returns mixed or null `LessonNo` values.

## Root Cause
The `HomeWorks` response schema validated `LessonNo` as `v.number()` even though live Librus payloads include numeric strings and `null`.

## Validation
- `npm run lint`
- `npm run build`
- `npm test`
