### PR TITLE
[codex] Release 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-03-29
+
 ### Fixed
 
 - Homework validation now accepts mixed and null `HomeWork.LessonNo` values returned by the live API.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "librus-sdk",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "librus-sdk",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librus-sdk",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "TypeScript SDK and CLI for the Librus family portal flow.",
   "author": "Andrey Koltsov",
   "repository": {


### PR DESCRIPTION
## Summary

Prepare the `0.2.1` patch release.

This PR:
- bumps the package version from `0.2.0` to `0.2.1`
- promotes the current `Unreleased` homework validation fix into a dated `0.2.1` changelog entry
- leaves a fresh `Unreleased` section for follow-up work

No new code changes are introduced here; this is the release-preparation step for the homework `LessonNo` validation fix that has already landed on `master`.

## Why

PR #19 fixed live API compatibility for homework payloads. We need a patch release so npm consumers can pick up that fix.

## Impact

After this PR is merged, tagging `v0.2.1` from `master` will publish the patch release.

## Validation

- `npm run validate`
