### PR TITLE
[codex] Release 0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-03-29
+
+### Fixed
+
+- Homework validation now accepts live `HomeWork.Subject` values that are omitted entirely or returned as `null`.
+
 ## [0.2.1] - 2026-03-29
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ npm run cli -- attendance list --child <id-or-login>
 npm run cli -- homework list --child <id-or-login>
 ```
 
-`HomeWork.LessonNo` mirrors the live Librus payload and may be `string`, `number`, or `null`.
+`HomeWork.LessonNo` mirrors the live Librus payload and may be `string`, `number`, or `null`. `HomeWork.Subject` may be omitted entirely or returned as `null`.
 
 ## SDK usage
 
@@ -69,6 +69,6 @@ const children = await session.listChildren();
 console.log(children);
 ```
 
-`await session.forChild(child).getHomeWorks()` preserves the API's `HomeWork.LessonNo` value as `string`, `number`, or `null`.
+`await session.forChild(child).getHomeWorks()` preserves the API's `HomeWork.LessonNo` value as `string`, `number`, or `null`, and leaves `HomeWork.Subject` absent when the API omits it.
 
 All commands write JSON to stdout by default. Errors are written as JSON to stderr and return a non-zero exit code.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "librus-sdk",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "librus-sdk",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librus-sdk",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "TypeScript SDK and CLI for the Librus family portal flow.",
   "author": "Andrey Koltsov",
   "repository": {

--- a/src/sdk/models/synergia.ts
+++ b/src/sdk/models/synergia.ts
@@ -64,7 +64,7 @@ export interface HomeWork {
   Date: string;
   Id: number;
   LessonNo: string | number | null;
-  Subject: JsonObject | ApiRef | null;
+  Subject?: JsonObject | ApiRef | null;
   TimeFrom: string | null;
   TimeTo: string | null;
 }

--- a/src/sdk/validation/schemas.ts
+++ b/src/sdk/validation/schemas.ts
@@ -96,7 +96,7 @@ const homeWorkSchema = v.looseObject({
   Date: v.string(),
   Id: v.number(),
   LessonNo: v.union([v.string(), v.number(), v.null()]),
-  Subject: v.union([apiRefOrJsonSchema, v.null()]),
+  Subject: v.exactOptional(v.union([apiRefOrJsonSchema, v.null()])),
   TimeFrom: v.union([v.string(), v.null()]),
   TimeTo: v.union([v.string(), v.null()]),
 });

--- a/test/synergia-client.test.ts
+++ b/test/synergia-client.test.ts
@@ -117,7 +117,7 @@ describe("SynergiaApiClient", () => {
     expect(response.Attendances[1]?.Trip).toBeUndefined();
   });
 
-  it("accepts homework payloads with string, numeric, or null lesson numbers", async () => {
+  it("accepts homework payloads with mixed lesson numbers and missing subjects", async () => {
     const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
       new Response(
         JSON.stringify({
@@ -147,10 +147,6 @@ describe("SynergiaApiClient", () => {
               Date: "2026-03-30",
               Id: 2,
               LessonNo: 2,
-              Subject: {
-                Id: 11,
-                Url: "https://api.librus.pl/3.0/Subjects/11",
-              },
               TimeFrom: "09:00",
               TimeTo: "09:45",
             },
@@ -185,5 +181,12 @@ describe("SynergiaApiClient", () => {
     expect(response.HomeWorks[0]?.LessonNo).toBe("5");
     expect(response.HomeWorks[1]?.LessonNo).toBe(2);
     expect(response.HomeWorks[2]?.LessonNo).toBeNull();
+    expect(response.HomeWorks[0]?.Subject).toEqual({
+      Id: 10,
+      Url: "https://api.librus.pl/3.0/Subjects/10",
+    });
+    expect(Object.hasOwn(response.HomeWorks[1]!, "Subject")).toBe(false);
+    expect(response.HomeWorks[1]?.Subject).toBeUndefined();
+    expect(response.HomeWorks[2]?.Subject).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- fix `HomeWorks` validation so homework items are accepted when `Subject` is omitted in live API responses
- align the public `HomeWork` type and README notes with the runtime payload shape
- bump the package and changelog for the `0.2.2` bugfix release

## Root cause
`0.2.1` relaxed `HomeWork.LessonNo`, but the `HomeWorks` response schema still required a `Subject` key. Some live accounts omit that key entirely, which caused `RESPONSE_VALIDATION_FAILED` for both the CLI and SDK.

## Impact
This restores `homework list` and `getHomeWorks()` for accounts where Librus omits `Subject`, while preserving absent values instead of normalizing them.

## Validation
- `npm run validate`
- `node ./scripts/extract-release-notes.mjs 0.2.2`
