### PR TITLE
[codex] Add text/json CLI output formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Public `SynergiaBinaryResult` export for attachment-style SDK methods such as `getHomeworkAssignmentAttachment(id)`.
 - Generated `openapi.json` for the SDK-supported child-scoped Synergia GET surface, plus a public `generateOpenApiDocument()` helper and npm regeneration scripts.
 
+### Changed
+
+- CLI leaf commands now accept `--format <text|json>`, default to human-readable text output, and keep `json` as the full machine-readable format.
+- CLI errors now follow the selected output format, and download commands report saved-file metadata in text by default.
+
 ## [0.2.2] - 2026-03-29
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ console.log(children);
 
 The SDK also exposes widget-derived GET coverage for timetable, messages, announcements, notes, school/class metadata, lessons, lucky number, notification settings, justifications, parent-teacher conferences, system data, and auth-related reads. Attachment methods such as `getHomeworkAssignmentAttachment(id)`, `getMessageAttachment(id)`, and `getPlannedLessonAttachment(id)` return `{ data, contentType, contentDisposition }`.
 
-`getAuthPhoto(id)` mirrors the live API and returns JSON with the photo payload under `data.photo`, including base64 content in `data.photo.content`. The CLI `auth photo --output <path>` command decodes that content to a file and still writes JSON metadata to stdout.
+`getAuthPhoto(id)` mirrors the live API and returns JSON with the photo payload under `data.photo`, including base64 content in `data.photo.content`. The CLI `auth photo --output <path>` command decodes that content to a file and reports the saved-file metadata in text by default or JSON with `--format json`.
 
 ## OpenAPI
 
@@ -142,4 +142,4 @@ import { generateOpenApiDocument } from "librus-sdk";
 const openApi = generateOpenApiDocument({ version: "0.2.2" });
 ```
 
-All commands write JSON to stdout by default. Errors are written as JSON to stderr and return a non-zero exit code. Download commands such as `lessons planned-attachment` and `auth photo` write the requested file and then emit JSON metadata describing the saved output.
+Leaf commands write structured text to stdout by default. Pass `--format json` for stable machine-readable output. Errors follow the selected format on stderr and return a non-zero exit code. Download commands such as `lessons planned-attachment` and `auth photo` write the requested file and then report metadata describing the saved output.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@valibot/to-json-schema": "^1.6.0",
+        "cliui": "^9.0.1",
         "commander": "^14.0.0",
         "dotenv": "^17.2.3",
         "fetch-cookie": "^3.1.0",
@@ -1582,7 +1583,6 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -1595,7 +1595,6 @@
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -1692,6 +1691,37 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/colorette": {
       "version": "2.0.20",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
@@ -1781,7 +1811,6 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/entities": {
@@ -2185,7 +2214,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
       "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -3282,7 +3310,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
       "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.2.2"
@@ -3711,7 +3738,6 @@
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
       "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.2.1",
@@ -3729,7 +3755,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
       "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^10.3.0",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
   "license": "MIT",
   "dependencies": {
     "@valibot/to-json-schema": "^1.6.0",
+    "cliui": "^9.0.1",
     "commander": "^14.0.0",
     "dotenv": "^17.2.3",
     "fetch-cookie": "^3.1.0",

--- a/src/cli/commands/announcements.ts
+++ b/src/cli/commands/announcements.ts
@@ -2,10 +2,10 @@ import { Command } from "commander";
 
 import type { CliContext } from "./common.js";
 import {
-  addJsonOption,
+  addFormatOption,
   configureCommand,
-  summarizeChildAccount,
-  writeJson,
+  type CliFormatOptions,
+  writeChildScopedOutput,
 } from "./common.js";
 
 export function createAnnouncementsCommand(context: CliContext): Command {
@@ -14,42 +14,40 @@ export function createAnnouncementsCommand(context: CliContext): Command {
     context,
   );
   const list = configureCommand(
-    addJsonOption(new Command("list").description("List school announcements")),
+    addFormatOption(
+      new Command("list").description("List school announcements"),
+    ),
     context,
   );
   const get = configureCommand(
-    addJsonOption(
+    addFormatOption(
       new Command("get").description("Get a school announcement by id"),
     ),
     context,
   );
 
   list.requiredOption("--child <id-or-login>", "Child account id or login");
-  list.action(async (options: { child: string }) => {
+  list.action(async (options: CliFormatOptions & { child: string }) => {
     const session = context.createSession();
     const child = await session.resolveChild(options.child);
     const client = await session.forChild(child);
     const data = await client.listSchoolNotices();
 
-    writeJson(context.stdout, {
-      child: summarizeChildAccount(child),
-      data,
-    });
+    writeChildScopedOutput(context, options.format, child, data);
   });
 
   get.requiredOption("--child <id-or-login>", "Child account id or login");
   get.requiredOption("--id <id>", "Announcement id");
-  get.action(async (options: { child: string; id: string }) => {
-    const session = context.createSession();
-    const child = await session.resolveChild(options.child);
-    const client = await session.forChild(child);
-    const data = await client.getSchoolNotice(options.id);
+  get.action(
+    async (options: CliFormatOptions & { child: string; id: string }) => {
+      const session = context.createSession();
+      const child = await session.resolveChild(options.child);
+      const client = await session.forChild(child);
+      const data = await client.getSchoolNotice(options.id);
 
-    writeJson(context.stdout, {
-      child: summarizeChildAccount(child),
-      data,
-    });
-  });
+      writeChildScopedOutput(context, options.format, child, data);
+    },
+  );
 
   announcements.addCommand(list);
   announcements.addCommand(get);

--- a/src/cli/commands/attendance.ts
+++ b/src/cli/commands/attendance.ts
@@ -2,10 +2,10 @@ import { Command } from "commander";
 
 import type { CliContext } from "./common.js";
 import {
-  addJsonOption,
+  addFormatOption,
   configureCommand,
-  summarizeChildAccount,
-  writeJson,
+  type CliFormatOptions,
+  writeChildScopedOutput,
 } from "./common.js";
 
 export function createAttendanceCommand(context: CliContext): Command {
@@ -14,23 +14,20 @@ export function createAttendanceCommand(context: CliContext): Command {
     context,
   );
   const list = configureCommand(
-    addJsonOption(
+    addFormatOption(
       new Command("list").description("List attendances for a child"),
     ),
     context,
   );
 
   list.requiredOption("--child <id-or-login>", "Child account id or login");
-  list.action(async (options: { child: string }) => {
+  list.action(async (options: CliFormatOptions & { child: string }) => {
     const session = context.createSession();
     const child = await session.resolveChild(options.child);
     const client = await session.forChild(child);
     const data = await client.getAttendances();
 
-    writeJson(context.stdout, {
-      child: summarizeChildAccount(child),
-      data,
-    });
+    writeChildScopedOutput(context, options.format, child, data);
   });
 
   attendance.addCommand(list);

--- a/src/cli/commands/auth.ts
+++ b/src/cli/commands/auth.ts
@@ -4,11 +4,12 @@ import { LibrusSdkError } from "../../sdk/index.js";
 import type { AuthPhoto } from "../../sdk/models/synergia/auth.js";
 import type { CliContext } from "./common.js";
 import {
-  addJsonOption,
+  addFormatOption,
   configureCommand,
-  summarizeChildAccount,
+  createSingleDataSection,
+  type CliFormatOptions,
   writeBase64Download,
-  writeJson,
+  writeChildScopedOutput,
 } from "./common.js";
 
 function inferContentTypeFromFileName(fileName?: string): string | null {
@@ -57,47 +58,55 @@ export function createAuthCommand(context: CliContext): Command {
     context,
   );
   const photos = configureCommand(
-    addJsonOption(new Command("photos").description("List auth photos")),
+    addFormatOption(new Command("photos").description("List auth photos")),
     context,
   );
   const photo = configureCommand(
-    addJsonOption(
+    addFormatOption(
       new Command("photo").description("Download an auth photo by id"),
     ),
     context,
   );
   const userInfo = configureCommand(
-    addJsonOption(
+    addFormatOption(
       new Command("user-info").description("Get auth user info by id"),
     ),
     context,
   );
   const tokenInfo = configureCommand(
-    addJsonOption(new Command("token-info").description("Get auth token info")),
+    addFormatOption(
+      new Command("token-info").description("Get auth token info"),
+    ),
     context,
   );
   const classroom = configureCommand(
-    addJsonOption(
+    addFormatOption(
       new Command("classroom").description("Get auth classroom data by id"),
     ),
     context,
   );
 
   photos.requiredOption("--child <id-or-login>", "Child account id or login");
-  photos.action(async (options: { child: string }) => {
+  photos.action(async (options: CliFormatOptions & { child: string }) => {
     const session = context.createSession();
     const child = await session.resolveChild(options.child);
     const client = await session.forChild(child);
     const data = await client.listAuthPhotos();
 
-    writeJson(context.stdout, { child: summarizeChildAccount(child), data });
+    writeChildScopedOutput(context, options.format, child, data);
   });
 
   photo.requiredOption("--child <id-or-login>", "Child account id or login");
   photo.requiredOption("--id <id>", "Photo id");
   photo.requiredOption("--output <path>", "Write the photo to this file path");
   photo.action(
-    async (options: { child: string; id: string; output: string }) => {
+    async (
+      options: CliFormatOptions & {
+        child: string;
+        id: string;
+        output: string;
+      },
+    ) => {
       const session = context.createSession();
       const child = await session.resolveChild(options.child);
       const client = await session.forChild(child);
@@ -112,35 +121,43 @@ export function createAuthCommand(context: CliContext): Command {
         },
       );
 
-      writeJson(context.stdout, {
-        child: summarizeChildAccount(child),
+      writeChildScopedOutput(
+        context,
+        options.format,
+        child,
         data,
-      });
+        (summary) => [
+          { title: "Child", value: summary },
+          ...createSingleDataSection("Saved File", data),
+        ],
+      );
     },
   );
 
   userInfo.requiredOption("--child <id-or-login>", "Child account id or login");
   userInfo.requiredOption("--id <id>", "User identifier");
-  userInfo.action(async (options: { child: string; id: string }) => {
-    const session = context.createSession();
-    const child = await session.resolveChild(options.child);
-    const client = await session.forChild(child);
-    const data = await client.getAuthUserInfo(options.id);
+  userInfo.action(
+    async (options: CliFormatOptions & { child: string; id: string }) => {
+      const session = context.createSession();
+      const child = await session.resolveChild(options.child);
+      const client = await session.forChild(child);
+      const data = await client.getAuthUserInfo(options.id);
 
-    writeJson(context.stdout, { child: summarizeChildAccount(child), data });
-  });
+      writeChildScopedOutput(context, options.format, child, data);
+    },
+  );
 
   tokenInfo.requiredOption(
     "--child <id-or-login>",
     "Child account id or login",
   );
-  tokenInfo.action(async (options: { child: string }) => {
+  tokenInfo.action(async (options: CliFormatOptions & { child: string }) => {
     const session = context.createSession();
     const child = await session.resolveChild(options.child);
     const client = await session.forChild(child);
     const data = await client.getAuthTokenInfo();
 
-    writeJson(context.stdout, { child: summarizeChildAccount(child), data });
+    writeChildScopedOutput(context, options.format, child, data);
   });
 
   classroom.requiredOption(
@@ -148,14 +165,16 @@ export function createAuthCommand(context: CliContext): Command {
     "Child account id or login",
   );
   classroom.requiredOption("--id <id>", "Classroom id");
-  classroom.action(async (options: { child: string; id: string }) => {
-    const session = context.createSession();
-    const child = await session.resolveChild(options.child);
-    const client = await session.forChild(child);
-    const data = await client.getAuthClassroom(options.id);
+  classroom.action(
+    async (options: CliFormatOptions & { child: string; id: string }) => {
+      const session = context.createSession();
+      const child = await session.resolveChild(options.child);
+      const client = await session.forChild(child);
+      const data = await client.getAuthClassroom(options.id);
 
-    writeJson(context.stdout, { child: summarizeChildAccount(child), data });
-  });
+      writeChildScopedOutput(context, options.format, child, data);
+    },
+  );
 
   auth.addCommand(photos);
   auth.addCommand(photo);

--- a/src/cli/commands/children.ts
+++ b/src/cli/commands/children.ts
@@ -2,10 +2,11 @@ import { Command } from "commander";
 
 import type { CliContext } from "./common.js";
 import {
-  addJsonOption,
+  addFormatOption,
+  type CliFormatOptions,
   configureCommand,
   summarizeChildAccount,
-  writeJson,
+  writeCommandOutput,
 } from "./common.js";
 
 export function createChildrenCommand(context: CliContext): Command {
@@ -14,20 +15,32 @@ export function createChildrenCommand(context: CliContext): Command {
     context,
   );
   const list = configureCommand(
-    addJsonOption(
+    addFormatOption(
       new Command("list").description("List linked child accounts"),
     ),
     context,
   );
 
-  list.action(async () => {
+  list.action(async (options: CliFormatOptions) => {
     const session = context.createSession();
     const response = await session.getSynergiaAccounts();
-
-    writeJson(context.stdout, {
+    const payload = {
       lastModification: response.lastModification,
       children: response.accounts.map(summarizeChildAccount),
-    });
+    };
+
+    writeCommandOutput(context, options.format, payload, () => [
+      {
+        title: "Response",
+        value: {
+          lastModification: payload.lastModification,
+        },
+      },
+      {
+        title: "Children",
+        value: payload.children,
+      },
+    ]);
   });
 
   children.addCommand(list);

--- a/src/cli/commands/common.ts
+++ b/src/cli/commands/common.ts
@@ -1,5 +1,5 @@
 import { writeFileSync } from "node:fs";
-import type { Command } from "commander";
+import { InvalidArgumentError, type Command } from "commander";
 
 import {
   LibrusSession,
@@ -7,6 +7,22 @@ import {
   type ChildAccount,
   type ChildAccountSummary,
 } from "../../sdk/index.js";
+import { renderTextSections, type CliTextSection } from "../output/render.js";
+
+const DEFAULT_OUTPUT_WIDTH = 80;
+
+export type CliOutputFormat = "json" | "text";
+export type CliTextVariant = "default" | "full";
+
+export interface CliFormatOptions {
+  format: CliOutputFormat;
+}
+
+export interface CliRenderOptions {
+  format: CliOutputFormat;
+  textVariant: CliTextVariant;
+  width: number;
+}
 
 export interface CliOutput {
   write(chunk: string): void;
@@ -16,6 +32,7 @@ export interface CliContext {
   stdout: CliOutput;
   stderr: CliOutput;
   createSession: () => LibrusSession;
+  outputWidth?: number;
   writeFile?: (path: string, data: Uint8Array) => void;
 }
 
@@ -32,8 +49,13 @@ export function configureCommand(
     .exitOverride();
 }
 
-export function addJsonOption(command: Command): Command {
-  return command.option("--json", "Emit JSON output");
+export function addFormatOption(command: Command): Command {
+  return command.option(
+    "--format <format>",
+    "Emit output in text or json",
+    parseCliOutputFormat,
+    "text",
+  );
 }
 
 export function summarizeChildAccount(
@@ -45,6 +67,90 @@ export function summarizeChildAccount(
 
 export function writeJson(output: CliOutput, value: unknown): void {
   output.write(`${JSON.stringify(value, null, 2)}\n`);
+}
+
+export function createCliRenderOptions(
+  context: CliContext,
+  format: CliOutputFormat,
+): CliRenderOptions {
+  return {
+    format,
+    textVariant: format === "json" ? "full" : "default",
+    width: context.outputWidth ?? DEFAULT_OUTPUT_WIDTH,
+  };
+}
+
+export function detectCliOutputFormat(argv: string[]): CliOutputFormat {
+  let format: CliOutputFormat = "text";
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (!arg) {
+      continue;
+    }
+
+    if (arg === "--format") {
+      const nextArg = argv[index + 1];
+
+      if (nextArg === "json" || nextArg === "text") {
+        format = nextArg;
+      }
+
+      continue;
+    }
+
+    if (arg.startsWith("--format=")) {
+      const value = arg.slice("--format=".length);
+
+      if (value === "json" || value === "text") {
+        format = value;
+      }
+    }
+  }
+
+  return format;
+}
+
+export function writeCommandOutput<T>(
+  context: CliContext,
+  format: CliOutputFormat,
+  value: T,
+  buildTextSections: (textVariant: CliTextVariant) => CliTextSection[],
+): void {
+  const renderOptions = createCliRenderOptions(context, format);
+
+  if (renderOptions.format === "json") {
+    writeJson(context.stdout, value);
+    return;
+  }
+
+  context.stdout.write(
+    renderTextSections(buildTextSections(renderOptions.textVariant), {
+      width: renderOptions.width,
+    }),
+  );
+}
+
+export function writeCliError(
+  output: CliOutput,
+  renderOptions: CliRenderOptions,
+  error: unknown,
+): void {
+  const payload = {
+    error: formatCliError(error),
+  };
+
+  if (renderOptions.format === "json") {
+    writeJson(output, payload);
+    return;
+  }
+
+  output.write(
+    renderTextSections([{ title: "Error", value: payload.error }], {
+      width: renderOptions.width,
+    }),
+  );
 }
 
 export function formatCliError(error: unknown): {
@@ -80,6 +186,91 @@ export function formatCliError(error: unknown): {
     code: "INTERNAL_ERROR",
     message: "Unexpected error",
   };
+}
+
+export function createSingleDataSection(
+  title: string,
+  value: unknown,
+): CliTextSection[] {
+  return [{ title, value }];
+}
+
+export function createTopLevelDataSections(
+  value: unknown,
+  fallbackTitle = "Data",
+): CliTextSection[] {
+  if (
+    value === null ||
+    typeof value !== "object" ||
+    Array.isArray(value) ||
+    value instanceof Date
+  ) {
+    return [{ title: fallbackTitle, value }];
+  }
+
+  const sections: CliTextSection[] = [];
+  const metadata: Record<string, unknown> = {};
+
+  for (const [key, entryValue] of Object.entries(value)) {
+    if (entryValue === undefined) {
+      continue;
+    }
+
+    if (key === "Resources" || key === "Url") {
+      metadata[key] = entryValue;
+      continue;
+    }
+
+    sections.push({
+      title: humanizeHeading(key),
+      value: entryValue,
+    });
+  }
+
+  if (Object.keys(metadata).length > 0) {
+    sections.push({
+      title: "Metadata",
+      value: metadata,
+    });
+  }
+
+  if (sections.length === 0) {
+    return [{ title: fallbackTitle, value }];
+  }
+
+  return sections;
+}
+
+export function createChildScopedSections(
+  child: ChildAccountSummary,
+  data: unknown,
+): CliTextSection[] {
+  return [
+    { title: "Child", value: child },
+    ...createTopLevelDataSections(data),
+  ];
+}
+
+export function writeChildScopedOutput(
+  context: CliContext,
+  format: CliOutputFormat,
+  child: ChildAccount,
+  data: unknown,
+  buildTextSections:
+    | ((child: ChildAccountSummary) => CliTextSection[])
+    | null = null,
+): void {
+  const summary = summarizeChildAccount(child);
+  const payload = {
+    child: summary,
+    data,
+  };
+
+  writeCommandOutput(context, format, payload, () =>
+    buildTextSections
+      ? buildTextSections(summary)
+      : createChildScopedSections(summary, data),
+  );
 }
 
 export interface CliDownloadResult {
@@ -153,4 +344,21 @@ export function writeBase64Download(
     contentDisposition: metadata.contentDisposition ?? null,
     contentType: metadata.contentType ?? decoded.contentType,
   };
+}
+
+function parseCliOutputFormat(value: string): CliOutputFormat {
+  if (value === "text" || value === "json") {
+    return value;
+  }
+
+  throw new InvalidArgumentError('Expected "text" or "json".');
+}
+
+function humanizeHeading(value: string): string {
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/[-_]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/\b\w/g, (character) => character.toUpperCase());
 }

--- a/src/cli/commands/grades.ts
+++ b/src/cli/commands/grades.ts
@@ -2,10 +2,10 @@ import { Command } from "commander";
 
 import type { CliContext } from "./common.js";
 import {
-  addJsonOption,
+  addFormatOption,
   configureCommand,
-  summarizeChildAccount,
-  writeJson,
+  type CliFormatOptions,
+  writeChildScopedOutput,
 } from "./common.js";
 
 export function createGradesCommand(context: CliContext): Command {
@@ -14,21 +14,18 @@ export function createGradesCommand(context: CliContext): Command {
     context,
   );
   const list = configureCommand(
-    addJsonOption(new Command("list").description("List grades for a child")),
+    addFormatOption(new Command("list").description("List grades for a child")),
     context,
   );
 
   list.requiredOption("--child <id-or-login>", "Child account id or login");
-  list.action(async (options: { child: string }) => {
+  list.action(async (options: CliFormatOptions & { child: string }) => {
     const session = context.createSession();
     const child = await session.resolveChild(options.child);
     const client = await session.forChild(child);
     const data = await client.getGrades();
 
-    writeJson(context.stdout, {
-      child: summarizeChildAccount(child),
-      data,
-    });
+    writeChildScopedOutput(context, options.format, child, data);
   });
 
   grades.addCommand(list);

--- a/src/cli/commands/homework.ts
+++ b/src/cli/commands/homework.ts
@@ -2,10 +2,10 @@ import { Command } from "commander";
 
 import type { CliContext } from "./common.js";
 import {
-  addJsonOption,
+  addFormatOption,
   configureCommand,
-  summarizeChildAccount,
-  writeJson,
+  type CliFormatOptions,
+  writeChildScopedOutput,
 } from "./common.js";
 
 export function createHomeworkCommand(context: CliContext): Command {
@@ -14,21 +14,20 @@ export function createHomeworkCommand(context: CliContext): Command {
     context,
   );
   const list = configureCommand(
-    addJsonOption(new Command("list").description("List homework for a child")),
+    addFormatOption(
+      new Command("list").description("List homework for a child"),
+    ),
     context,
   );
 
   list.requiredOption("--child <id-or-login>", "Child account id or login");
-  list.action(async (options: { child: string }) => {
+  list.action(async (options: CliFormatOptions & { child: string }) => {
     const session = context.createSession();
     const child = await session.resolveChild(options.child);
     const client = await session.forChild(child);
     const data = await client.getHomeWorks();
 
-    writeJson(context.stdout, {
-      child: summarizeChildAccount(child),
-      data,
-    });
+    writeChildScopedOutput(context, options.format, child, data);
   });
 
   homework.addCommand(list);

--- a/src/cli/commands/justifications.ts
+++ b/src/cli/commands/justifications.ts
@@ -2,10 +2,10 @@ import { Command } from "commander";
 
 import type { CliContext } from "./common.js";
 import {
-  addJsonOption,
+  addFormatOption,
   configureCommand,
-  summarizeChildAccount,
-  writeJson,
+  type CliFormatOptions,
+  writeChildScopedOutput,
 } from "./common.js";
 
 export function createJustificationsCommand(context: CliContext): Command {
@@ -14,21 +14,23 @@ export function createJustificationsCommand(context: CliContext): Command {
     context,
   );
   const list = configureCommand(
-    addJsonOption(new Command("list").description("List justifications")),
+    addFormatOption(new Command("list").description("List justifications")),
     context,
   );
   const get = configureCommand(
-    addJsonOption(new Command("get").description("Get a justification by id")),
+    addFormatOption(
+      new Command("get").description("Get a justification by id"),
+    ),
     context,
   );
   const conferences = configureCommand(
-    addJsonOption(
+    addFormatOption(
       new Command("conferences").description("List parent-teacher conferences"),
     ),
     context,
   );
   const systemData = configureCommand(
-    addJsonOption(
+    addFormatOption(
       new Command("system-data").description("Get system date and time"),
     ),
     context,
@@ -39,52 +41,58 @@ export function createJustificationsCommand(context: CliContext): Command {
     "--date-from <YYYY-MM-DD>",
     "Request justifications from this date onward",
   );
-  list.action(async (options: { child: string; dateFrom?: string }) => {
-    const session = context.createSession();
-    const child = await session.resolveChild(options.child);
-    const client = await session.forChild(child);
-    const data = await client.listJustifications(
-      options.dateFrom ? { dateFrom: options.dateFrom } : {},
-    );
+  list.action(
+    async (
+      options: CliFormatOptions & { child: string; dateFrom?: string },
+    ) => {
+      const session = context.createSession();
+      const child = await session.resolveChild(options.child);
+      const client = await session.forChild(child);
+      const data = await client.listJustifications(
+        options.dateFrom ? { dateFrom: options.dateFrom } : {},
+      );
 
-    writeJson(context.stdout, { child: summarizeChildAccount(child), data });
-  });
+      writeChildScopedOutput(context, options.format, child, data);
+    },
+  );
 
   get.requiredOption("--child <id-or-login>", "Child account id or login");
   get.requiredOption("--id <id>", "Justification id");
-  get.action(async (options: { child: string; id: string }) => {
-    const session = context.createSession();
-    const child = await session.resolveChild(options.child);
-    const client = await session.forChild(child);
-    const data = await client.getJustification(options.id);
+  get.action(
+    async (options: CliFormatOptions & { child: string; id: string }) => {
+      const session = context.createSession();
+      const child = await session.resolveChild(options.child);
+      const client = await session.forChild(child);
+      const data = await client.getJustification(options.id);
 
-    writeJson(context.stdout, { child: summarizeChildAccount(child), data });
-  });
+      writeChildScopedOutput(context, options.format, child, data);
+    },
+  );
 
   conferences.requiredOption(
     "--child <id-or-login>",
     "Child account id or login",
   );
-  conferences.action(async (options: { child: string }) => {
+  conferences.action(async (options: CliFormatOptions & { child: string }) => {
     const session = context.createSession();
     const child = await session.resolveChild(options.child);
     const client = await session.forChild(child);
     const data = await client.listParentTeacherConferences();
 
-    writeJson(context.stdout, { child: summarizeChildAccount(child), data });
+    writeChildScopedOutput(context, options.format, child, data);
   });
 
   systemData.requiredOption(
     "--child <id-or-login>",
     "Child account id or login",
   );
-  systemData.action(async (options: { child: string }) => {
+  systemData.action(async (options: CliFormatOptions & { child: string }) => {
     const session = context.createSession();
     const child = await session.resolveChild(options.child);
     const client = await session.forChild(child);
     const data = await client.getSystemData();
 
-    writeJson(context.stdout, { child: summarizeChildAccount(child), data });
+    writeChildScopedOutput(context, options.format, child, data);
   });
 
   justifications.addCommand(list);

--- a/src/cli/commands/lessons.ts
+++ b/src/cli/commands/lessons.ts
@@ -2,11 +2,12 @@ import { Command } from "commander";
 
 import type { CliContext } from "./common.js";
 import {
-  addJsonOption,
+  addFormatOption,
   configureCommand,
-  summarizeChildAccount,
+  createSingleDataSection,
+  type CliFormatOptions,
   writeBinaryDownload,
-  writeJson,
+  writeChildScopedOutput,
 } from "./common.js";
 
 export function createLessonsCommand(context: CliContext): Command {
@@ -15,27 +16,27 @@ export function createLessonsCommand(context: CliContext): Command {
     context,
   );
   const list = configureCommand(
-    addJsonOption(new Command("list").description("List lessons")),
+    addFormatOption(new Command("list").description("List lessons")),
     context,
   );
   const get = configureCommand(
-    addJsonOption(new Command("get").description("Get a lesson by id")),
+    addFormatOption(new Command("get").description("Get a lesson by id")),
     context,
   );
   const plannedList = configureCommand(
-    addJsonOption(
+    addFormatOption(
       new Command("planned-list").description("List planned lessons"),
     ),
     context,
   );
   const plannedGet = configureCommand(
-    addJsonOption(
+    addFormatOption(
       new Command("planned-get").description("Get a planned lesson by id"),
     ),
     context,
   );
   const plannedAttachment = configureCommand(
-    addJsonOption(
+    addFormatOption(
       new Command("planned-attachment").description(
         "Download a planned lesson attachment",
       ),
@@ -43,13 +44,13 @@ export function createLessonsCommand(context: CliContext): Command {
     context,
   );
   const realizationsList = configureCommand(
-    addJsonOption(
+    addFormatOption(
       new Command("realizations-list").description("List lesson realizations"),
     ),
     context,
   );
   const realizationsGet = configureCommand(
-    addJsonOption(
+    addFormatOption(
       new Command("realizations-get").description(
         "Get a lesson realization by id",
       ),
@@ -58,37 +59,39 @@ export function createLessonsCommand(context: CliContext): Command {
   );
 
   list.requiredOption("--child <id-or-login>", "Child account id or login");
-  list.action(async (options: { child: string }) => {
+  list.action(async (options: CliFormatOptions & { child: string }) => {
     const session = context.createSession();
     const child = await session.resolveChild(options.child);
     const client = await session.forChild(child);
     const data = await client.listLessons();
 
-    writeJson(context.stdout, { child: summarizeChildAccount(child), data });
+    writeChildScopedOutput(context, options.format, child, data);
   });
 
   get.requiredOption("--child <id-or-login>", "Child account id or login");
   get.requiredOption("--id <id>", "Lesson id");
-  get.action(async (options: { child: string; id: string }) => {
-    const session = context.createSession();
-    const child = await session.resolveChild(options.child);
-    const client = await session.forChild(child);
-    const data = await client.getLesson(options.id);
+  get.action(
+    async (options: CliFormatOptions & { child: string; id: string }) => {
+      const session = context.createSession();
+      const child = await session.resolveChild(options.child);
+      const client = await session.forChild(child);
+      const data = await client.getLesson(options.id);
 
-    writeJson(context.stdout, { child: summarizeChildAccount(child), data });
-  });
+      writeChildScopedOutput(context, options.format, child, data);
+    },
+  );
 
   plannedList.requiredOption(
     "--child <id-or-login>",
     "Child account id or login",
   );
-  plannedList.action(async (options: { child: string }) => {
+  plannedList.action(async (options: CliFormatOptions & { child: string }) => {
     const session = context.createSession();
     const child = await session.resolveChild(options.child);
     const client = await session.forChild(child);
     const data = await client.listPlannedLessons();
 
-    writeJson(context.stdout, { child: summarizeChildAccount(child), data });
+    writeChildScopedOutput(context, options.format, child, data);
   });
 
   plannedGet.requiredOption(
@@ -96,14 +99,16 @@ export function createLessonsCommand(context: CliContext): Command {
     "Child account id or login",
   );
   plannedGet.requiredOption("--id <id>", "Planned lesson id");
-  plannedGet.action(async (options: { child: string; id: string }) => {
-    const session = context.createSession();
-    const child = await session.resolveChild(options.child);
-    const client = await session.forChild(child);
-    const data = await client.getPlannedLesson(options.id);
+  plannedGet.action(
+    async (options: CliFormatOptions & { child: string; id: string }) => {
+      const session = context.createSession();
+      const child = await session.resolveChild(options.child);
+      const client = await session.forChild(child);
+      const data = await client.getPlannedLesson(options.id);
 
-    writeJson(context.stdout, { child: summarizeChildAccount(child), data });
-  });
+      writeChildScopedOutput(context, options.format, child, data);
+    },
+  );
 
   plannedAttachment.requiredOption(
     "--child <id-or-login>",
@@ -115,17 +120,29 @@ export function createLessonsCommand(context: CliContext): Command {
     "Write the attachment to this file path",
   );
   plannedAttachment.action(
-    async (options: { child: string; id: string; output: string }) => {
+    async (
+      options: CliFormatOptions & {
+        child: string;
+        id: string;
+        output: string;
+      },
+    ) => {
       const session = context.createSession();
       const child = await session.resolveChild(options.child);
       const client = await session.forChild(child);
       const file = await client.getPlannedLessonAttachment(options.id);
       const data = writeBinaryDownload(context, options.output, file);
 
-      writeJson(context.stdout, {
-        child: summarizeChildAccount(child),
+      writeChildScopedOutput(
+        context,
+        options.format,
+        child,
         data,
-      });
+        (summary) => [
+          { title: "Child", value: summary },
+          ...createSingleDataSection("Saved File", data),
+        ],
+      );
     },
   );
 
@@ -133,28 +150,32 @@ export function createLessonsCommand(context: CliContext): Command {
     "--child <id-or-login>",
     "Child account id or login",
   );
-  realizationsList.action(async (options: { child: string }) => {
-    const session = context.createSession();
-    const child = await session.resolveChild(options.child);
-    const client = await session.forChild(child);
-    const data = await client.listRealizations();
+  realizationsList.action(
+    async (options: CliFormatOptions & { child: string }) => {
+      const session = context.createSession();
+      const child = await session.resolveChild(options.child);
+      const client = await session.forChild(child);
+      const data = await client.listRealizations();
 
-    writeJson(context.stdout, { child: summarizeChildAccount(child), data });
-  });
+      writeChildScopedOutput(context, options.format, child, data);
+    },
+  );
 
   realizationsGet.requiredOption(
     "--child <id-or-login>",
     "Child account id or login",
   );
   realizationsGet.requiredOption("--id <id>", "Realization id");
-  realizationsGet.action(async (options: { child: string; id: string }) => {
-    const session = context.createSession();
-    const child = await session.resolveChild(options.child);
-    const client = await session.forChild(child);
-    const data = await client.getRealization(options.id);
+  realizationsGet.action(
+    async (options: CliFormatOptions & { child: string; id: string }) => {
+      const session = context.createSession();
+      const child = await session.resolveChild(options.child);
+      const client = await session.forChild(child);
+      const data = await client.getRealization(options.id);
 
-    writeJson(context.stdout, { child: summarizeChildAccount(child), data });
-  });
+      writeChildScopedOutput(context, options.format, child, data);
+    },
+  );
 
   lessons.addCommand(list);
   lessons.addCommand(get);

--- a/src/cli/commands/luckyNumber.ts
+++ b/src/cli/commands/luckyNumber.ts
@@ -2,10 +2,10 @@ import { Command } from "commander";
 
 import type { CliContext } from "./common.js";
 import {
-  addJsonOption,
+  addFormatOption,
   configureCommand,
-  summarizeChildAccount,
-  writeJson,
+  type CliFormatOptions,
+  writeChildScopedOutput,
 } from "./common.js";
 
 export function createLuckyNumberCommand(context: CliContext): Command {
@@ -14,20 +14,22 @@ export function createLuckyNumberCommand(context: CliContext): Command {
     context,
   );
   const get = configureCommand(
-    addJsonOption(new Command("get").description("Get the lucky number")),
+    addFormatOption(new Command("get").description("Get the lucky number")),
     context,
   );
 
   get.requiredOption("--child <id-or-login>", "Child account id or login");
   get.option("--for-day <YYYY-MM-DD>", "Request the lucky number for a day");
-  get.action(async (options: { child: string; forDay?: string }) => {
-    const session = context.createSession();
-    const child = await session.resolveChild(options.child);
-    const client = await session.forChild(child);
-    const data = await client.getLuckyNumber(options.forDay);
+  get.action(
+    async (options: CliFormatOptions & { child: string; forDay?: string }) => {
+      const session = context.createSession();
+      const child = await session.resolveChild(options.child);
+      const client = await session.forChild(child);
+      const data = await client.getLuckyNumber(options.forDay);
 
-    writeJson(context.stdout, { child: summarizeChildAccount(child), data });
-  });
+      writeChildScopedOutput(context, options.format, child, data);
+    },
+  );
 
   luckyNumber.addCommand(get);
 

--- a/src/cli/commands/me.ts
+++ b/src/cli/commands/me.ts
@@ -2,29 +2,26 @@ import { Command } from "commander";
 
 import type { CliContext } from "./common.js";
 import {
-  addJsonOption,
+  addFormatOption,
   configureCommand,
-  summarizeChildAccount,
-  writeJson,
+  type CliFormatOptions,
+  writeChildScopedOutput,
 } from "./common.js";
 
 export function createMeCommand(context: CliContext): Command {
   const me = configureCommand(
-    addJsonOption(new Command("me").description("Get child profile data")),
+    addFormatOption(new Command("me").description("Get child profile data")),
     context,
   );
 
   me.requiredOption("--child <id-or-login>", "Child account id or login");
-  me.action(async (options: { child: string }) => {
+  me.action(async (options: CliFormatOptions & { child: string }) => {
     const session = context.createSession();
     const child = await session.resolveChild(options.child);
     const client = await session.forChild(child);
     const data = await client.getMe();
 
-    writeJson(context.stdout, {
-      child: summarizeChildAccount(child),
-      data,
-    });
+    writeChildScopedOutput(context, options.format, child, data);
   });
 
   return me;

--- a/src/cli/commands/messages.ts
+++ b/src/cli/commands/messages.ts
@@ -2,10 +2,10 @@ import { Command } from "commander";
 
 import type { CliContext } from "./common.js";
 import {
-  addJsonOption,
+  addFormatOption,
   configureCommand,
-  summarizeChildAccount,
-  writeJson,
+  type CliFormatOptions,
+  writeChildScopedOutput,
 } from "./common.js";
 
 export function createMessagesCommand(context: CliContext): Command {
@@ -14,15 +14,17 @@ export function createMessagesCommand(context: CliContext): Command {
     context,
   );
   const list = configureCommand(
-    addJsonOption(new Command("list").description("List messages for a child")),
+    addFormatOption(
+      new Command("list").description("List messages for a child"),
+    ),
     context,
   );
   const get = configureCommand(
-    addJsonOption(new Command("get").description("Get a message by id")),
+    addFormatOption(new Command("get").description("Get a message by id")),
     context,
   );
   const unread = configureCommand(
-    addJsonOption(
+    addFormatOption(
       new Command("unread").description("List unread messages for a child"),
     ),
     context,
@@ -30,45 +32,40 @@ export function createMessagesCommand(context: CliContext): Command {
 
   list.requiredOption("--child <id-or-login>", "Child account id or login");
   list.option("--after-id <id>", "List messages after the given message id");
-  list.action(async (options: { afterId?: string; child: string }) => {
-    const session = context.createSession();
-    const child = await session.resolveChild(options.child);
-    const client = await session.forChild(child);
-    const data = await client.listMessages(
-      options.afterId ? { afterId: options.afterId } : {},
-    );
+  list.action(
+    async (options: CliFormatOptions & { afterId?: string; child: string }) => {
+      const session = context.createSession();
+      const child = await session.resolveChild(options.child);
+      const client = await session.forChild(child);
+      const data = await client.listMessages(
+        options.afterId ? { afterId: options.afterId } : {},
+      );
 
-    writeJson(context.stdout, {
-      child: summarizeChildAccount(child),
-      data,
-    });
-  });
+      writeChildScopedOutput(context, options.format, child, data);
+    },
+  );
 
   get.requiredOption("--child <id-or-login>", "Child account id or login");
   get.requiredOption("--id <id>", "Message id");
-  get.action(async (options: { child: string; id: string }) => {
-    const session = context.createSession();
-    const child = await session.resolveChild(options.child);
-    const client = await session.forChild(child);
-    const data = await client.getMessage(options.id);
+  get.action(
+    async (options: CliFormatOptions & { child: string; id: string }) => {
+      const session = context.createSession();
+      const child = await session.resolveChild(options.child);
+      const client = await session.forChild(child);
+      const data = await client.getMessage(options.id);
 
-    writeJson(context.stdout, {
-      child: summarizeChildAccount(child),
-      data,
-    });
-  });
+      writeChildScopedOutput(context, options.format, child, data);
+    },
+  );
 
   unread.requiredOption("--child <id-or-login>", "Child account id or login");
-  unread.action(async (options: { child: string }) => {
+  unread.action(async (options: CliFormatOptions & { child: string }) => {
     const session = context.createSession();
     const child = await session.resolveChild(options.child);
     const client = await session.forChild(child);
     const data = await client.getUnreadMessages();
 
-    writeJson(context.stdout, {
-      child: summarizeChildAccount(child),
-      data,
-    });
+    writeChildScopedOutput(context, options.format, child, data);
   });
 
   messages.addCommand(list);

--- a/src/cli/commands/notes.ts
+++ b/src/cli/commands/notes.ts
@@ -2,10 +2,10 @@ import { Command } from "commander";
 
 import type { CliContext } from "./common.js";
 import {
-  addJsonOption,
+  addFormatOption,
   configureCommand,
-  summarizeChildAccount,
-  writeJson,
+  type CliFormatOptions,
+  writeChildScopedOutput,
 } from "./common.js";
 
 export function createNotesCommand(context: CliContext): Command {
@@ -14,40 +14,36 @@ export function createNotesCommand(context: CliContext): Command {
     context,
   );
   const list = configureCommand(
-    addJsonOption(new Command("list").description("List notes for a child")),
+    addFormatOption(new Command("list").description("List notes for a child")),
     context,
   );
   const get = configureCommand(
-    addJsonOption(new Command("get").description("Get a note by id")),
+    addFormatOption(new Command("get").description("Get a note by id")),
     context,
   );
 
   list.requiredOption("--child <id-or-login>", "Child account id or login");
-  list.action(async (options: { child: string }) => {
+  list.action(async (options: CliFormatOptions & { child: string }) => {
     const session = context.createSession();
     const child = await session.resolveChild(options.child);
     const client = await session.forChild(child);
     const data = await client.listNotes();
 
-    writeJson(context.stdout, {
-      child: summarizeChildAccount(child),
-      data,
-    });
+    writeChildScopedOutput(context, options.format, child, data);
   });
 
   get.requiredOption("--child <id-or-login>", "Child account id or login");
   get.requiredOption("--id <id>", "Note id");
-  get.action(async (options: { child: string; id: string }) => {
-    const session = context.createSession();
-    const child = await session.resolveChild(options.child);
-    const client = await session.forChild(child);
-    const data = await client.getNote(options.id);
+  get.action(
+    async (options: CliFormatOptions & { child: string; id: string }) => {
+      const session = context.createSession();
+      const child = await session.resolveChild(options.child);
+      const client = await session.forChild(child);
+      const data = await client.getNote(options.id);
 
-    writeJson(context.stdout, {
-      child: summarizeChildAccount(child),
-      data,
-    });
-  });
+      writeChildScopedOutput(context, options.format, child, data);
+    },
+  );
 
   notes.addCommand(list);
   notes.addCommand(get);

--- a/src/cli/commands/notifications.ts
+++ b/src/cli/commands/notifications.ts
@@ -2,10 +2,10 @@ import { Command } from "commander";
 
 import type { CliContext } from "./common.js";
 import {
-  addJsonOption,
+  addFormatOption,
   configureCommand,
-  summarizeChildAccount,
-  writeJson,
+  type CliFormatOptions,
+  writeChildScopedOutput,
 } from "./common.js";
 
 export function createNotificationsCommand(context: CliContext): Command {
@@ -14,13 +14,13 @@ export function createNotificationsCommand(context: CliContext): Command {
     context,
   );
   const center = configureCommand(
-    addJsonOption(
+    addFormatOption(
       new Command("center").description("Get notification center settings"),
     ),
     context,
   );
   const pushConfigurations = configureCommand(
-    addJsonOption(
+    addFormatOption(
       new Command("push-configurations").description(
         "Get push notification configuration",
       ),
@@ -29,27 +29,29 @@ export function createNotificationsCommand(context: CliContext): Command {
   );
 
   center.requiredOption("--child <id-or-login>", "Child account id or login");
-  center.action(async (options: { child: string }) => {
+  center.action(async (options: CliFormatOptions & { child: string }) => {
     const session = context.createSession();
     const child = await session.resolveChild(options.child);
     const client = await session.forChild(child);
     const data = await client.getNotificationCenter();
 
-    writeJson(context.stdout, { child: summarizeChildAccount(child), data });
+    writeChildScopedOutput(context, options.format, child, data);
   });
 
   pushConfigurations.requiredOption(
     "--child <id-or-login>",
     "Child account id or login",
   );
-  pushConfigurations.action(async (options: { child: string }) => {
-    const session = context.createSession();
-    const child = await session.resolveChild(options.child);
-    const client = await session.forChild(child);
-    const data = await client.getPushConfigurations();
+  pushConfigurations.action(
+    async (options: CliFormatOptions & { child: string }) => {
+      const session = context.createSession();
+      const child = await session.resolveChild(options.child);
+      const client = await session.forChild(child);
+      const data = await client.getPushConfigurations();
 
-    writeJson(context.stdout, { child: summarizeChildAccount(child), data });
-  });
+      writeChildScopedOutput(context, options.format, child, data);
+    },
+  );
 
   notifications.addCommand(center);
   notifications.addCommand(pushConfigurations);

--- a/src/cli/commands/timetable.ts
+++ b/src/cli/commands/timetable.ts
@@ -2,10 +2,10 @@ import { Command } from "commander";
 
 import type { CliContext } from "./common.js";
 import {
-  addJsonOption,
+  addFormatOption,
   configureCommand,
-  summarizeChildAccount,
-  writeJson,
+  type CliFormatOptions,
+  writeChildScopedOutput,
 } from "./common.js";
 
 export function createTimetableCommand(context: CliContext): Command {
@@ -14,19 +14,19 @@ export function createTimetableCommand(context: CliContext): Command {
     context,
   );
   const week = configureCommand(
-    addJsonOption(
+    addFormatOption(
       new Command("week").description("Get timetable entries for a week"),
     ),
     context,
   );
   const day = configureCommand(
-    addJsonOption(
+    addFormatOption(
       new Command("day").description("Get timetable entries for a day"),
     ),
     context,
   );
   const entry = configureCommand(
-    addJsonOption(
+    addFormatOption(
       new Command("entry").description("Get a timetable entry by id"),
     ),
     context,
@@ -34,45 +34,44 @@ export function createTimetableCommand(context: CliContext): Command {
 
   week.requiredOption("--child <id-or-login>", "Child account id or login");
   week.requiredOption("--week-start <YYYY-MM-DD>", "Week start date");
-  week.action(async (options: { child: string; weekStart: string }) => {
-    const session = context.createSession();
-    const child = await session.resolveChild(options.child);
-    const client = await session.forChild(child);
-    const data = await client.getTimetableWeek(options.weekStart);
+  week.action(
+    async (
+      options: CliFormatOptions & { child: string; weekStart: string },
+    ) => {
+      const session = context.createSession();
+      const child = await session.resolveChild(options.child);
+      const client = await session.forChild(child);
+      const data = await client.getTimetableWeek(options.weekStart);
 
-    writeJson(context.stdout, {
-      child: summarizeChildAccount(child),
-      data,
-    });
-  });
+      writeChildScopedOutput(context, options.format, child, data);
+    },
+  );
 
   day.requiredOption("--child <id-or-login>", "Child account id or login");
   day.requiredOption("--day <YYYY-MM-DD>", "Day");
-  day.action(async (options: { child: string; day: string }) => {
-    const session = context.createSession();
-    const child = await session.resolveChild(options.child);
-    const client = await session.forChild(child);
-    const data = await client.getTimetableDay(options.day);
+  day.action(
+    async (options: CliFormatOptions & { child: string; day: string }) => {
+      const session = context.createSession();
+      const child = await session.resolveChild(options.child);
+      const client = await session.forChild(child);
+      const data = await client.getTimetableDay(options.day);
 
-    writeJson(context.stdout, {
-      child: summarizeChildAccount(child),
-      data,
-    });
-  });
+      writeChildScopedOutput(context, options.format, child, data);
+    },
+  );
 
   entry.requiredOption("--child <id-or-login>", "Child account id or login");
   entry.requiredOption("--id <id>", "Timetable entry id");
-  entry.action(async (options: { child: string; id: string }) => {
-    const session = context.createSession();
-    const child = await session.resolveChild(options.child);
-    const client = await session.forChild(child);
-    const data = await client.getTimetableEntry(options.id);
+  entry.action(
+    async (options: CliFormatOptions & { child: string; id: string }) => {
+      const session = context.createSession();
+      const child = await session.resolveChild(options.child);
+      const client = await session.forChild(child);
+      const data = await client.getTimetableEntry(options.id);
 
-    writeJson(context.stdout, {
-      child: summarizeChildAccount(child),
-      data,
-    });
-  });
+      writeChildScopedOutput(context, options.format, child, data);
+    },
+  );
 
   timetable.addCommand(week);
   timetable.addCommand(day);

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -13,8 +13,9 @@ import { createChildrenCommand } from "./commands/children.js";
 import type { CliContext } from "./commands/common.js";
 import {
   configureCommand,
-  formatCliError,
-  writeJson,
+  createCliRenderOptions,
+  detectCliOutputFormat,
+  writeCliError,
 } from "./commands/common.js";
 import { createGradesCommand } from "./commands/grades.js";
 import { createHomeworkCommand } from "./commands/homework.js";
@@ -40,6 +41,7 @@ export function createDefaultCliContext(): CliContext {
       write: (chunk) => process.stderr.write(chunk),
     },
     createSession: () => LibrusSession.fromEnv(),
+    outputWidth: process.stdout.columns ?? 80,
     writeFile: (path, data) => writeFileSync(path, data),
   };
 }
@@ -91,6 +93,11 @@ export async function runCli(
     await program.parseAsync(argv);
     return 0;
   } catch (error) {
+    const renderOptions = createCliRenderOptions(
+      context,
+      detectCliOutputFormat(userArgs),
+    );
+
     if (
       error instanceof Error &&
       "code" in error &&
@@ -103,9 +110,7 @@ export async function runCli(
       return 0;
     }
 
-    writeJson(context.stderr, {
-      error: formatCliError(error),
-    });
+    writeCliError(context.stderr, renderOptions, error);
 
     return error instanceof Error &&
       "exitCode" in error &&

--- a/src/cli/output/cliui.d.ts
+++ b/src/cli/output/cliui.d.ts
@@ -1,0 +1,23 @@
+declare module "cliui" {
+  export interface CliUiOptions {
+    width?: number;
+    wrap?: boolean;
+  }
+
+  export interface CliUiColumn {
+    align?: "center" | "right";
+    border?: boolean;
+    padding?: [number, number, number, number];
+    text: string;
+    width?: number;
+  }
+
+  export interface CliUiInstance {
+    div(...columns: Array<CliUiColumn | string>): void;
+    resetOutput(): void;
+    span(...columns: Array<CliUiColumn | string>): void;
+    toString(): string;
+  }
+
+  export default function cliui(options?: CliUiOptions): CliUiInstance;
+}

--- a/src/cli/output/render.ts
+++ b/src/cli/output/render.ts
@@ -1,0 +1,188 @@
+import cliui from "cliui";
+
+export interface CliTextSection {
+  title: string;
+  value: unknown;
+}
+
+interface RenderTextSectionsOptions {
+  width: number;
+}
+
+const INDENT_SIZE = 2;
+const MIN_LABEL_WIDTH = 8;
+const MAX_LABEL_WIDTH = 24;
+
+type CliUiInstance = ReturnType<typeof cliui>;
+
+export function renderTextSections(
+  sections: CliTextSection[],
+  options: RenderTextSectionsOptions,
+): string {
+  const ui = cliui({
+    width: options.width,
+    wrap: true,
+  });
+
+  sections.forEach((section, index) => {
+    if (index > 0) {
+      ui.div("");
+    }
+
+    ui.div({ text: section.title });
+    appendValue(ui, section.value, INDENT_SIZE);
+  });
+
+  return `${ui.toString().trimEnd()}\n`;
+}
+
+function appendValue(ui: CliUiInstance, value: unknown, indent: number): void {
+  if (Array.isArray(value)) {
+    appendArray(ui, value, indent);
+    return;
+  }
+
+  if (isRenderableObject(value)) {
+    appendObject(ui, value, indent);
+    return;
+  }
+
+  appendLine(ui, `${indentation(indent)}${formatScalar(value)}`);
+}
+
+function appendArray(
+  ui: CliUiInstance,
+  items: unknown[],
+  indent: number,
+): void {
+  if (items.length === 0) {
+    appendLine(ui, `${indentation(indent)}[]`);
+    return;
+  }
+
+  for (const item of items) {
+    if (isScalar(item)) {
+      appendLine(ui, `${indentation(indent)}- ${formatScalar(item)}`);
+      continue;
+    }
+
+    appendLine(ui, `${indentation(indent)}-`);
+    appendValue(ui, item, indent + INDENT_SIZE);
+  }
+}
+
+function appendObject(
+  ui: CliUiInstance,
+  value: Record<string, unknown>,
+  indent: number,
+): void {
+  const entries = Object.entries(value).filter(
+    ([, entryValue]) => entryValue !== undefined,
+  );
+
+  if (entries.length === 0) {
+    appendLine(ui, `${indentation(indent)}{}`);
+    return;
+  }
+
+  const scalarEntries = entries.filter(([, entryValue]) =>
+    isScalar(entryValue),
+  );
+  const complexEntries = entries.filter(
+    ([, entryValue]) => !isScalar(entryValue),
+  );
+
+  if (scalarEntries.length > 0) {
+    const labelWidth = getLabelWidth(
+      scalarEntries.map(([label]) => label.length),
+    );
+
+    for (const [label, entryValue] of scalarEntries) {
+      appendKeyValueRow(ui, indent, label, entryValue, labelWidth);
+    }
+  }
+
+  for (const [label, entryValue] of complexEntries) {
+    appendLine(ui, `${indentation(indent)}${label}`);
+    appendValue(ui, entryValue, indent + INDENT_SIZE);
+  }
+}
+
+function appendKeyValueRow(
+  ui: CliUiInstance,
+  indent: number,
+  label: string,
+  value: unknown,
+  labelWidth: number,
+): void {
+  ui.div(
+    {
+      text: `${indentation(indent)}${label}:`,
+      width: indent + labelWidth + 2,
+    },
+    {
+      text: formatScalar(value),
+    },
+  );
+}
+
+function appendLine(ui: CliUiInstance, text: string): void {
+  ui.div({ text });
+}
+
+function getLabelWidth(labelLengths: number[]): number {
+  const maxLength = Math.max(...labelLengths);
+
+  return Math.min(Math.max(maxLength, MIN_LABEL_WIDTH), MAX_LABEL_WIDTH);
+}
+
+function indentation(indent: number): string {
+  return " ".repeat(indent);
+}
+
+function isRenderableObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isScalar(value: unknown): boolean {
+  return (
+    value === null ||
+    value === undefined ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    typeof value === "bigint"
+  );
+}
+
+function formatScalar(value: unknown): string {
+  if (value === null) {
+    return "null";
+  }
+
+  if (value === undefined) {
+    return "undefined";
+  }
+
+  if (typeof value === "string") {
+    if (value.length === 0) {
+      return '""';
+    }
+
+    if (/[\r\n\t]/.test(value) || value.trim() !== value) {
+      return JSON.stringify(value);
+    }
+
+    return value;
+  }
+
+  if (
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    typeof value === "bigint"
+  ) {
+    return String(value);
+  }
+
+  return JSON.stringify(value);
+}

--- a/test/cli-high-value.test.ts
+++ b/test/cli-high-value.test.ts
@@ -20,6 +20,10 @@ function parseJson<T>(value: string): T {
   return JSON.parse(value) as T;
 }
 
+function withJsonFormat(argv: string[]): string[] {
+  return [...argv, "--format", "json"];
+}
+
 function createCommandContext(
   method: string,
   response: unknown,
@@ -39,6 +43,7 @@ function createCommandContext(
     context: {
       stdout: { write: (chunk: string) => (stdout += chunk) },
       stderr: { write: (chunk: string) => (stderr += chunk) },
+      outputWidth: 80,
       createSession: () =>
         ({
           resolveChild,
@@ -299,7 +304,7 @@ describe("runCli high-value commands", () => {
       const { apiMethod, child, context, forChild, getOutput, resolveChild } =
         createCommandContext(method, response);
 
-      const exitCode = await runCli(argv, context);
+      const exitCode = await runCli(withJsonFormat(argv), context);
       const output = parseJson<{ child: { login: string }; data: unknown }>(
         getOutput().stdout,
       );
@@ -319,10 +324,11 @@ describe("runCli high-value commands", () => {
     async ({ argv, expectedMessage }) => {
       let stderr = "";
 
-      const exitCode = await runCli(argv, {
+      const exitCode = await runCli(withJsonFormat(argv), {
         stdout: { write: () => undefined },
         stderr: { write: (chunk) => (stderr += chunk) },
         createSession: () => ({}) as never,
+        outputWidth: 80,
       });
 
       const output = parseJson<{ error: { code: string; message: string } }>(
@@ -343,6 +349,7 @@ describe("runCli high-value commands", () => {
       {
         stdout: { write: () => undefined },
         stderr: { write: (chunk) => (stderr += chunk) },
+        outputWidth: 80,
         createSession: () =>
           ({
             resolveChild: async () => createChild(),
@@ -364,5 +371,24 @@ describe("runCli high-value commands", () => {
     expect(stderr).toContain("API_REQUEST_FAILED");
     expect(stderr).not.toContain("token-secret");
     expect(stderr).not.toContain("Bearer ");
+  });
+
+  it("renders text output by default for messages list", async () => {
+    const { context, getOutput } = createCommandContext("listMessages", {
+      Messages: [],
+      Resources: {},
+      Url: "https://api.librus.pl/3.0/Messages",
+    });
+
+    const exitCode = await runCli(
+      ["node", "librus", "messages", "list", "--child", "child-login"],
+      context,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(getOutput().stderr).toBe("");
+    expect(getOutput().stdout).toContain("Child");
+    expect(getOutput().stdout).toContain("Messages");
+    expect(getOutput().stdout).toContain("Metadata");
   });
 });

--- a/test/cli-supporting.test.ts
+++ b/test/cli-supporting.test.ts
@@ -20,6 +20,10 @@ function parseJson<T>(value: string): T {
   return JSON.parse(value) as T;
 }
 
+function withJsonFormat(argv: string[]): string[] {
+  return [...argv, "--format", "json"];
+}
+
 function createCommandContext(
   method: string,
   response: unknown,
@@ -39,6 +43,7 @@ function createCommandContext(
     context: {
       stdout: { write: (chunk: string) => (stdout += chunk) },
       stderr: { write: (chunk: string) => (stderr += chunk) },
+      outputWidth: 80,
       createSession: () =>
         ({
           resolveChild,
@@ -444,7 +449,7 @@ describe("supporting CLI commands", () => {
       const { apiMethod, context, getOutput, resolveChild, forChild } =
         createCommandContext(method, response);
 
-      const exitCode = await runCli(argv, context);
+      const exitCode = await runCli(withJsonFormat(argv), context);
       const output = parseJson<{ child: ChildAccount; data: unknown }>(
         getOutput().stdout,
       );
@@ -473,7 +478,7 @@ describe("supporting CLI commands", () => {
     const forChild = vi.fn().mockResolvedValue({ getPlannedLessonAttachment });
 
     const exitCode = await runCli(
-      [
+      withJsonFormat([
         "node",
         "librus",
         "lessons",
@@ -484,10 +489,11 @@ describe("supporting CLI commands", () => {
         "attachment-1",
         "--output",
         "/tmp/planned.pdf",
-      ],
+      ]),
       {
         stdout: { write: (chunk) => (stdout += chunk) },
         stderr: { write: (chunk) => (stderr += chunk) },
+        outputWidth: 80,
         createSession: () =>
           ({
             resolveChild,
@@ -537,7 +543,7 @@ describe("supporting CLI commands", () => {
     const forChild = vi.fn().mockResolvedValue({ getAuthPhoto });
 
     const exitCode = await runCli(
-      [
+      withJsonFormat([
         "node",
         "librus",
         "auth",
@@ -548,10 +554,11 @@ describe("supporting CLI commands", () => {
         "photo-1",
         "--output",
         "/tmp/photo.jpg",
-      ],
+      ]),
       {
         stdout: { write: (chunk) => (stdout += chunk) },
         stderr: { write: (chunk) => (stderr += chunk) },
+        outputWidth: 80,
         createSession: () =>
           ({
             resolveChild,
@@ -595,7 +602,7 @@ describe("supporting CLI commands", () => {
     const forChild = vi.fn().mockResolvedValue({ getAuthPhoto });
 
     const exitCode = await runCli(
-      [
+      withJsonFormat([
         "node",
         "librus",
         "auth",
@@ -606,10 +613,11 @@ describe("supporting CLI commands", () => {
         "photo-1",
         "--output",
         "/tmp/photo.jpg",
-      ],
+      ]),
       {
         stdout: { write: () => undefined },
         stderr: { write: (chunk) => (stderr += chunk) },
+        outputWidth: 80,
         createSession: () =>
           ({
             resolveChild,
@@ -630,9 +638,10 @@ describe("supporting CLI commands", () => {
   it.each(usageFailureCases)("$name", async ({ argv, expectedMessage }) => {
     let stderr = "";
 
-    const exitCode = await runCli(argv, {
+    const exitCode = await runCli(withJsonFormat(argv), {
       stdout: { write: () => undefined },
       stderr: { write: (chunk) => (stderr += chunk) },
+      outputWidth: 80,
       createSession: () =>
         ({
           resolveChild: vi.fn(),
@@ -647,5 +656,24 @@ describe("supporting CLI commands", () => {
     expect(exitCode).not.toBe(0);
     expect(output.error.code).toBe("CLI_USAGE_ERROR");
     expect(output.error.message).toContain(expectedMessage);
+  });
+
+  it("renders text output by default for lessons list", async () => {
+    const { context, getOutput } = createCommandContext("listLessons", {
+      Lessons: [],
+      Resources: {},
+      Url: "https://api.librus.pl/3.0/Lessons",
+    });
+
+    const exitCode = await runCli(
+      ["node", "librus", "lessons", "list", "--child", "child-login"],
+      context,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(getOutput().stderr).toBe("");
+    expect(getOutput().stdout).toContain("Child");
+    expect(getOutput().stdout).toContain("Lessons");
+    expect(getOutput().stdout).toContain("Metadata");
   });
 });

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -57,15 +57,42 @@ function parseJson<T>(value: string): T {
   return JSON.parse(value) as T;
 }
 
+function withJsonFormat(argv: string[]): string[] {
+  return [...argv, "--format", "json"];
+}
+
 describe("runCli", () => {
-  it("writes success payloads to stdout", async () => {
+  it("writes text output by default", async () => {
     let stdout = "";
     let stderr = "";
     const exitCode = await runCli(["node", "librus", "children", "list"], {
       stdout: { write: (chunk) => (stdout += chunk) },
       stderr: { write: (chunk) => (stderr += chunk) },
       createSession: () => createSessionStub() as never,
+      outputWidth: 80,
     });
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe("");
+    expect(stdout).toContain("Response");
+    expect(stdout).toContain("lastModification:");
+    expect(stdout).toContain("Children");
+    expect(stdout).toContain("login:");
+    expect(stdout).not.toContain("accessToken");
+  });
+
+  it("writes JSON payloads to stdout for --format json", async () => {
+    let stdout = "";
+    let stderr = "";
+    const exitCode = await runCli(
+      withJsonFormat(["node", "librus", "children", "list"]),
+      {
+        stdout: { write: (chunk) => (stdout += chunk) },
+        stderr: { write: (chunk) => (stderr += chunk) },
+        createSession: () => createSessionStub() as never,
+        outputWidth: 80,
+      },
+    );
 
     const output = parseJson<{
       lastModification: number;
@@ -85,6 +112,7 @@ describe("runCli", () => {
       stdout: { write: (chunk) => (stdout += chunk) },
       stderr: { write: (chunk) => (stderr += chunk) },
       createSession: () => createSessionStub() as never,
+      outputWidth: 80,
     });
 
     expect(exitCode).toBe(0);
@@ -99,6 +127,7 @@ describe("runCli", () => {
       stdout: { write: (chunk) => (stdout += chunk) },
       stderr: { write: (chunk) => (stderr += chunk) },
       createSession: () => createSessionStub() as never,
+      outputWidth: 80,
     });
 
     expect(exitCode).toBe(0);
@@ -113,6 +142,7 @@ describe("runCli", () => {
       stdout: { write: (chunk) => (stdout += chunk) },
       stderr: { write: (chunk) => (stderr += chunk) },
       createSession: () => createSessionStub() as never,
+      outputWidth: 80,
     });
 
     expect(exitCode).toBe(0);
@@ -120,7 +150,35 @@ describe("runCli", () => {
     expect(stdout.trim()).toBe(packageJson.version);
   });
 
-  it("writes stable JSON errors to stderr", async () => {
+  it("writes stable JSON errors to stderr for --format json", async () => {
+    let stdout = "";
+    let stderr = "";
+    const exitCode = await runCli(
+      withJsonFormat(["node", "librus", "children", "list"]),
+      {
+        stdout: { write: (chunk) => (stdout += chunk) },
+        stderr: { write: (chunk) => (stderr += chunk) },
+        createSession: () => {
+          throw new LibrusSdkError(
+            "CONFIGURATION_ERROR",
+            "Missing portal credentials.",
+          );
+        },
+        outputWidth: 80,
+      },
+    );
+
+    const output = parseJson<{ error: { code: string; message: string } }>(
+      stderr,
+    );
+
+    expect(exitCode).toBe(1);
+    expect(stdout).toBe("");
+    expect(output.error.code).toBe("CONFIGURATION_ERROR");
+    expect(output.error.message).toBe("Missing portal credentials.");
+  });
+
+  it("writes text errors to stderr by default", async () => {
     let stdout = "";
     let stderr = "";
     const exitCode = await runCli(["node", "librus", "children", "list"], {
@@ -132,16 +190,15 @@ describe("runCli", () => {
           "Missing portal credentials.",
         );
       },
+      outputWidth: 80,
     });
-
-    const output = parseJson<{ error: { code: string; message: string } }>(
-      stderr,
-    );
 
     expect(exitCode).toBe(1);
     expect(stdout).toBe("");
-    expect(output.error.code).toBe("CONFIGURATION_ERROR");
-    expect(output.error.message).toBe("Missing portal credentials.");
+    expect(stderr).toContain("Error");
+    expect(stderr).toContain("code:");
+    expect(stderr).toContain("CONFIGURATION_ERROR");
+    expect(stderr).toContain("message:");
   });
 
   it("keeps usage errors as failures", async () => {
@@ -154,16 +211,32 @@ describe("runCli", () => {
       stdout: { write: () => undefined },
       stderr: { write: (chunk) => (stderr += chunk) },
       createSession: () => createSessionStub() as never,
+      outputWidth: 80,
     });
 
-    const output = parseJson<{ error: { code: string; message: string } }>(
-      stderr,
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("CLI_USAGE_ERROR");
+    expect(stderr).toContain("required option");
+    expect(processStderrWrite).not.toHaveBeenCalled();
+    processStderrWrite.mockRestore();
+  });
+
+  it("fails cleanly for invalid --format values", async () => {
+    let stderr = "";
+
+    const exitCode = await runCli(
+      ["node", "librus", "children", "list", "--format", "yaml"],
+      {
+        stdout: { write: () => undefined },
+        stderr: { write: (chunk) => (stderr += chunk) },
+        createSession: () => createSessionStub() as never,
+        outputWidth: 80,
+      },
     );
 
     expect(exitCode).not.toBe(0);
-    expect(output.error.code).toBe("CLI_USAGE_ERROR");
-    expect(processStderrWrite).not.toHaveBeenCalled();
-    processStderrWrite.mockRestore();
+    expect(stderr).toContain("CLI_USAGE_ERROR");
+    expect(stderr).toContain('Expected "text" or "json".');
   });
 
   it("does not leak bearer tokens in error payloads", async () => {
@@ -181,6 +254,7 @@ describe("runCli", () => {
           },
         );
       },
+      outputWidth: 80,
     });
 
     expect(exitCode).toBe(1);
@@ -203,6 +277,7 @@ describe("runCli", () => {
           },
         );
       },
+      outputWidth: 80,
     });
 
     expect(exitCode).toBe(1);

--- a/test/integration/helpers/cli.mjs
+++ b/test/integration/helpers/cli.mjs
@@ -417,8 +417,9 @@ function summarizeOrSkipCliStatus(result, status, reason) {
 
 export function runCliCommand(args, env = process.env) {
   assertBuiltCli();
+  const commandArgs = [...args, "--format", "json"];
 
-  const result = spawnSync(process.execPath, [cliEntryPath, ...args], {
+  const result = spawnSync(process.execPath, [cliEntryPath, ...commandArgs], {
     cwd: repoRoot,
     encoding: "utf8",
     env,
@@ -436,7 +437,7 @@ export function runCliCommand(args, env = process.env) {
 
   return {
     args,
-    command: `node dist/cli/main.js ${args.join(" ")}`,
+    command: `node dist/cli/main.js ${commandArgs.join(" ")}`,
     exitCode: result.status ?? 1,
     payload,
     parseError,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,6 @@
     "skipLibCheck": true,
     "resolveJsonModule": true
   },
-  "include": ["src/**/*.ts"],
+  "include": ["src/**/*.ts", "src/**/*.d.ts"],
   "exclude": ["dist", "node_modules", "test"]
 }


### PR DESCRIPTION
## Summary
- add `--format <text|json>` to all leaf CLI commands and make `text` the default output mode
- route success and error output through a shared renderer with a future-ready `textVariant` contract
- add a cliui-backed text renderer, keep JSON output full and stable, and update docs/tests for the new default

## Why
The CLI was JSON-only even for human terminal use. This change adds a readable default text mode while preserving JSON as the explicit scripting format and keeps the formatter architecture ready for a later `text-full` mode.

## Validation
- `npm run build`
- `npm run lint`
- `npm test`
- `npm run format:check`
