### PR TITLE
[codex] Release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-03-31
+
 ### Added
 
 - SDK GET coverage for the remaining widget-adjacent grade, behaviour, attendance-type, homework-assignment, and homework-category endpoints.
@@ -13,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - SDK GET coverage for supporting lessons, lucky number, notification settings, justifications, parent-teacher conferences, system data, and auth-related endpoints.
 - CLI commands for `messages`, `timetable`, `announcements`, and `notes`.
 - CLI commands for `lessons`, `lucky-number`, `notifications`, `justifications`, and `auth`.
-- CLI download commands that write files to `--output` paths and emit JSON metadata to stdout instead of raw bytes.
+- CLI download commands that write files to `--output` paths and then report saved-file metadata instead of raw bytes.
 - Auth photo CLI download support that decodes the live API's base64 JSON content before writing the output file.
 - Public `SynergiaBinaryResult` export for attachment-style SDK methods such as `getHomeworkAssignmentAttachment(id)`.
 - Generated `openapi.json` for the SDK-supported child-scoped Synergia GET surface, plus a public `generateOpenApiDocument()` helper and npm regeneration scripts.

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ You can also generate the document programmatically:
 ```ts
 import { generateOpenApiDocument } from "librus-sdk";
 
-const openApi = generateOpenApiDocument({ version: "0.2.2" });
+const openApi = generateOpenApiDocument({ version: "0.3.0" });
 ```
 
 Leaf commands write structured text to stdout by default. Pass `--format json` for stable machine-readable output. Errors follow the selected format on stderr and return a non-zero exit code. Download commands such as `lessons planned-attachment` and `auth photo` write the requested file and then report metadata describing the saved output.

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.3",
   "info": {
     "title": "Librus Synergia API (SDK-supported subset)",
-    "version": "0.2.2",
+    "version": "0.3.0",
     "description": "Best-effort OpenAPI document generated from the SDK's supported child-scoped Synergia GET surface. Authentication starts on portal.librus.pl; this document covers the subsequent bearer-token calls against api.librus.pl/3.0."
   },
   "servers": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "librus-sdk",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "librus-sdk",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@valibot/to-json-schema": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librus-sdk",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "TypeScript SDK and CLI for the Librus family portal flow.",
   "author": "Andrey Koltsov",
   "repository": {


### PR DESCRIPTION
## Summary
- bump the package version to `0.3.0`
- move the current release notes out of `Unreleased`
- refresh the checked-in OpenAPI document to match the new package version

## Validation
- `npm run validate`
- `node --env-file=/Users/andreykoltsov/work/librus-sdk/.env.integration.local --test test/integration/*.integration.test.mjs`
