### PR TITLE
[codex] Make message text output readable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- CLI text output now renders epoch-style `*Date` fields as local `YYYY-MM-DD HH:mm:ss` values and decodes escaped message bodies into readable terminal text with line breaks.
+
 ## [0.3.0] - 2026-03-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -142,4 +142,4 @@ import { generateOpenApiDocument } from "librus-sdk";
 const openApi = generateOpenApiDocument({ version: "0.3.0" });
 ```
 
-Leaf commands write structured text to stdout by default. Pass `--format json` for stable machine-readable output. Errors follow the selected format on stderr and return a non-zero exit code. Download commands such as `lessons planned-attachment` and `auth photo` write the requested file and then report metadata describing the saved output.
+Leaf commands write structured text to stdout by default. Pass `--format json` for stable machine-readable output. In text output, epoch-style `*Date` fields render in local `YYYY-MM-DD HH:mm:ss` format, and escaped message bodies decode Polish characters while turning `<br>` tags into terminal line breaks. Errors follow the selected format on stderr and return a non-zero exit code. Download commands such as `lessons planned-attachment` and `auth photo` write the requested file and then report metadata describing the saved output.

--- a/src/cli/output/render.ts
+++ b/src/cli/output/render.ts
@@ -14,6 +14,15 @@ const MIN_LABEL_WIDTH = 8;
 const MAX_LABEL_WIDTH = 24;
 
 type CliUiInstance = ReturnType<typeof cliui>;
+interface ScalarFormatContext {
+  label?: string;
+}
+
+interface ScalarEntry {
+  formattedValue: string;
+  isBlock: boolean;
+  label: string;
+}
 
 export function renderTextSections(
   sections: CliTextSection[],
@@ -36,7 +45,12 @@ export function renderTextSections(
   return `${ui.toString().trimEnd()}\n`;
 }
 
-function appendValue(ui: CliUiInstance, value: unknown, indent: number): void {
+function appendValue(
+  ui: CliUiInstance,
+  value: unknown,
+  indent: number,
+  context: ScalarFormatContext = {},
+): void {
   if (Array.isArray(value)) {
     appendArray(ui, value, indent);
     return;
@@ -47,7 +61,7 @@ function appendValue(ui: CliUiInstance, value: unknown, indent: number): void {
     return;
   }
 
-  appendLine(ui, `${indentation(indent)}${formatScalar(value)}`);
+  appendLine(ui, `${indentation(indent)}${formatScalar(value, context)}`);
 }
 
 function appendArray(
@@ -93,12 +107,28 @@ function appendObject(
   );
 
   if (scalarEntries.length > 0) {
-    const labelWidth = getLabelWidth(
-      scalarEntries.map(([label]) => label.length),
+    const preparedEntries = scalarEntries.map(([label, entryValue]) =>
+      prepareScalarEntry(label, entryValue),
     );
+    const inlineEntries = preparedEntries.filter((entry) => !entry.isBlock);
+    const labelWidth =
+      inlineEntries.length > 0
+        ? getLabelWidth(inlineEntries.map((entry) => entry.label.length))
+        : MIN_LABEL_WIDTH;
 
-    for (const [label, entryValue] of scalarEntries) {
-      appendKeyValueRow(ui, indent, label, entryValue, labelWidth);
+    for (const entry of preparedEntries) {
+      if (entry.isBlock) {
+        appendBlockScalar(ui, indent, entry.label, entry.formattedValue);
+        continue;
+      }
+
+      appendKeyValueRow(
+        ui,
+        indent,
+        entry.label,
+        entry.formattedValue,
+        labelWidth,
+      );
     }
   }
 
@@ -112,7 +142,7 @@ function appendKeyValueRow(
   ui: CliUiInstance,
   indent: number,
   label: string,
-  value: unknown,
+  formattedValue: string,
   labelWidth: number,
 ): void {
   ui.div(
@@ -121,9 +151,27 @@ function appendKeyValueRow(
       width: indent + labelWidth + 2,
     },
     {
-      text: formatScalar(value),
+      text: formattedValue,
     },
   );
+}
+
+function appendBlockScalar(
+  ui: CliUiInstance,
+  indent: number,
+  label: string,
+  formattedValue: string,
+): void {
+  appendLine(ui, `${indentation(indent)}${label}:`);
+
+  for (const line of formattedValue.split("\n")) {
+    if (line.length === 0) {
+      appendLine(ui, "");
+      continue;
+    }
+
+    appendLine(ui, `${indentation(indent + INDENT_SIZE)}${line}`);
+  }
 }
 
 function appendLine(ui: CliUiInstance, text: string): void {
@@ -155,7 +203,16 @@ function isScalar(value: unknown): boolean {
   );
 }
 
-function formatScalar(value: unknown): string {
+function formatScalar(
+  value: unknown,
+  context: ScalarFormatContext = {},
+): string {
+  const formattedDate = formatDateScalar(value, context.label);
+
+  if (formattedDate !== null) {
+    return formattedDate;
+  }
+
   if (value === null) {
     return "null";
   }
@@ -165,6 +222,12 @@ function formatScalar(value: unknown): string {
   }
 
   if (typeof value === "string") {
+    const formattedBody = formatBodyScalar(value, context.label);
+
+    if (formattedBody !== null) {
+      return formattedBody;
+    }
+
     if (value.length === 0) {
       return '""';
     }
@@ -185,4 +248,121 @@ function formatScalar(value: unknown): string {
   }
 
   return JSON.stringify(value);
+}
+
+function prepareScalarEntry(label: string, value: unknown): ScalarEntry {
+  const formattedValue = formatScalar(value, { label });
+
+  return {
+    formattedValue,
+    isBlock: formattedValue.includes("\n"),
+    label,
+  };
+}
+
+function formatDateScalar(
+  value: unknown,
+  label: string | undefined,
+): string | null {
+  if (!label?.endsWith("Date")) {
+    return null;
+  }
+
+  const timestamp = normalizeUnixTimestamp(value);
+
+  if (timestamp === null) {
+    return null;
+  }
+
+  const date = new Date(timestamp);
+
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  return formatLocalDateTime(date);
+}
+
+function normalizeUnixTimestamp(value: unknown): number | null {
+  if (typeof value === "number") {
+    if (!Number.isFinite(value) || !Number.isInteger(value)) {
+      return null;
+    }
+
+    return normalizeTimestampNumber(value);
+  }
+
+  if (typeof value === "bigint") {
+    return normalizeTimestampNumber(Number(value));
+  }
+
+  if (typeof value !== "string" || !/^-?\d+$/.test(value)) {
+    return null;
+  }
+
+  return normalizeTimestampNumber(Number(value));
+}
+
+function normalizeTimestampNumber(value: number): number | null {
+  const digits = Math.abs(value).toString().length;
+
+  if (digits === 10) {
+    return value * 1000;
+  }
+
+  if (digits === 13) {
+    return value;
+  }
+
+  return null;
+}
+
+function formatLocalDateTime(date: Date): string {
+  return [date.getFullYear(), pad(date.getMonth() + 1), pad(date.getDate())]
+    .join("-")
+    .concat(
+      ` ${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`,
+    );
+}
+
+function pad(value: number): string {
+  return String(value).padStart(2, "0");
+}
+
+function formatBodyScalar(
+  value: string,
+  label: string | undefined,
+): string | null {
+  if (label !== "Body") {
+    return null;
+  }
+
+  const decodedValue = hasJsonEscapes(value)
+    ? decodeJsonEscapedString(value)
+    : value;
+  const withLineBreaks = decodedValue.replace(/<br\s*\/?>/gi, "\n");
+
+  if (decodedValue !== value || withLineBreaks !== decodedValue) {
+    return withLineBreaks;
+  }
+
+  return null;
+}
+
+function hasJsonEscapes(value: string): boolean {
+  return /\\u[0-9a-fA-F]{4}|\\["\\/bfnrt]/.test(value);
+}
+
+function decodeJsonEscapedString(value: string): string {
+  const escaped = value
+    .replace(/"/g, '\\"')
+    .replace(/\r/g, "\\r")
+    .replace(/\n/g, "\\n")
+    .replace(/\t/g, "\\t");
+
+  try {
+    return JSON.parse(`"${escaped}"`) as string;
+  } catch {
+    return value;
+  }
 }

--- a/test/cli-high-value.test.ts
+++ b/test/cli-high-value.test.ts
@@ -24,6 +24,20 @@ function withJsonFormat(argv: string[]): string[] {
   return [...argv, "--format", "json"];
 }
 
+function formatLocalDateTime(timestamp: number): string {
+  const date = new Date(timestamp);
+
+  return [
+    date.getFullYear(),
+    String(date.getMonth() + 1).padStart(2, "0"),
+    String(date.getDate()).padStart(2, "0"),
+  ]
+    .join("-")
+    .concat(
+      ` ${String(date.getHours()).padStart(2, "0")}:${String(date.getMinutes()).padStart(2, "0")}:${String(date.getSeconds()).padStart(2, "0")}`,
+    );
+}
+
 function createCommandContext(
   method: string,
   response: unknown,
@@ -390,5 +404,88 @@ describe("runCli high-value commands", () => {
     expect(getOutput().stdout).toContain("Child");
     expect(getOutput().stdout).toContain("Messages");
     expect(getOutput().stdout).toContain("Metadata");
+  });
+
+  it("formats message dates and body text in text output", async () => {
+    const rawBody =
+      "Szanowni Pa\\u0144stwo,\\u003Cbr\\u003E\\u003Cbr\\u003Ewysy\\u0142am grafik obiad\\u00f3w.\\u003Cbr\\u003E\\u003Cbr\\u003EPozdrawiam\\u003Cbr\\u003EAleksandra Wojtasik";
+    const { context, getOutput } = createCommandContext("getMessage", {
+      Message: {
+        Id: 17,
+        ReadDate: 1757068051,
+        SendDate: "1757314190000",
+        Body: rawBody,
+      },
+      Resources: {},
+      Url: "https://api.librus.pl/3.0/Messages/17",
+    });
+
+    const exitCode = await runCli(
+      [
+        "node",
+        "librus",
+        "messages",
+        "get",
+        "--child",
+        "child-login",
+        "--id",
+        "17",
+      ],
+      context,
+    );
+
+    expect(exitCode).toBe(0);
+    expect(getOutput().stderr).toBe("");
+    expect(getOutput().stdout).toContain(
+      formatLocalDateTime(1757068051 * 1000),
+    );
+    expect(getOutput().stdout).toContain(formatLocalDateTime(1757314190000));
+    expect(getOutput().stdout).toContain("Szanowni Państwo,");
+    expect(getOutput().stdout).toContain("wysyłam grafik obiadów.");
+    expect(getOutput().stdout).toContain("Pozdrawiam");
+    expect(getOutput().stdout).not.toContain("1757068051");
+    expect(getOutput().stdout).not.toContain("1757314190000");
+    expect(getOutput().stdout).not.toContain("\\u0144");
+    expect(getOutput().stdout).not.toContain("<br>");
+  });
+
+  it("keeps raw message dates and body text in json output", async () => {
+    const rawBody =
+      "Szanowni Pa\\u0144stwo,\\u003Cbr\\u003E\\u003Cbr\\u003Ewysy\\u0142am grafik obiad\\u00f3w.\\u003Cbr\\u003E\\u003Cbr\\u003EPozdrawiam\\u003Cbr\\u003EAleksandra Wojtasik";
+    const { context, getOutput } = createCommandContext("getMessage", {
+      Message: {
+        Id: 17,
+        ReadDate: 1757068051,
+        SendDate: "1757314190000",
+        Body: rawBody,
+      },
+      Resources: {},
+      Url: "https://api.librus.pl/3.0/Messages/17",
+    });
+
+    const exitCode = await runCli(
+      withJsonFormat([
+        "node",
+        "librus",
+        "messages",
+        "get",
+        "--child",
+        "child-login",
+        "--id",
+        "17",
+      ]),
+      context,
+    );
+    const output = parseJson<{
+      data: {
+        Message: { Body: string; ReadDate: number; SendDate: string };
+      };
+    }>(getOutput().stdout);
+
+    expect(exitCode).toBe(0);
+    expect(getOutput().stderr).toBe("");
+    expect(output.data.Message.ReadDate).toBe(1757068051);
+    expect(output.data.Message.SendDate).toBe("1757314190000");
+    expect(output.data.Message.Body).toBe(rawBody);
   });
 });

--- a/test/render.test.ts
+++ b/test/render.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import { renderTextSections } from "../src/cli/output/render.js";
+
+function formatLocalDateTime(timestamp: number): string {
+  const date = new Date(timestamp);
+
+  return [
+    date.getFullYear(),
+    String(date.getMonth() + 1).padStart(2, "0"),
+    String(date.getDate()).padStart(2, "0"),
+  ]
+    .join("-")
+    .concat(
+      ` ${String(date.getHours()).padStart(2, "0")}:${String(date.getMinutes()).padStart(2, "0")}:${String(date.getSeconds()).padStart(2, "0")}`,
+    );
+}
+
+describe("renderTextSections", () => {
+  it("formats unix *Date fields in nested message payloads", () => {
+    const output = renderTextSections(
+      [
+        {
+          title: "Messages",
+          value: [
+            {
+              Id: 17,
+              ReadDate: 1757068051,
+              SendDate: "1757314190000",
+            },
+          ],
+        },
+      ],
+      { width: 120 },
+    );
+
+    expect(output).toContain(formatLocalDateTime(1757068051 * 1000));
+    expect(output).toContain(formatLocalDateTime(1757314190000));
+    expect(output).not.toContain("1757068051");
+    expect(output).not.toContain("1757314190000");
+  });
+
+  it("decodes escaped message body text and renders line breaks", () => {
+    const output = renderTextSections(
+      [
+        {
+          title: "Message",
+          value: {
+            Body: "Szanowni Pa\\u0144stwo,\\u003Cbr\\u003E\\u003Cbr\\u003Ewysy\\u0142am grafik obiad\\u00f3w.\\u003Cbr\\u003E\\u003Cbr\\u003EPozdrawiam\\u003Cbr\\u003EAleksandra Wojtasik",
+          },
+        },
+      ],
+      { width: 120 },
+    );
+
+    expect(output).toContain("Szanowni Państwo,");
+    expect(output).toContain("wysyłam grafik obiadów.");
+    expect(output).toContain("Pozdrawiam");
+    expect(output).toContain("Aleksandra Wojtasik");
+    expect(output).not.toContain("\\u0144");
+    expect(output).not.toContain("<br>");
+  });
+});


### PR DESCRIPTION
## Summary
- format epoch-style `*Date` fields in CLI text output as local `YYYY-MM-DD HH:mm:ss`
- decode double-escaped message `Body` text so Polish characters render correctly in the terminal
- render message `<br>` tags as terminal line breaks while leaving `--format json` payloads unchanged

## Why
Message payloads can include Unix timestamps in `*Date` fields and double-escaped body content such as `\\u0144` and `\\u003Cbr\\u003E`. The generic text renderer was printing those values verbatim, which made message output hard to read.

## Impact
Human-readable CLI output for messages is now readable in the terminal without changing SDK response shapes or machine-readable JSON output.

## Validation
- `npm run validate`
