### PR TITLE
[codex] Release 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-03-31
+
 ### Fixed
 
 - CLI text output now renders epoch-style `*Date` fields as local `YYYY-MM-DD HH:mm:ss` values and decodes escaped message bodies into readable terminal text with line breaks.

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ You can also generate the document programmatically:
 ```ts
 import { generateOpenApiDocument } from "librus-sdk";
 
-const openApi = generateOpenApiDocument({ version: "0.3.0" });
+const openApi = generateOpenApiDocument({ version: "0.3.1" });
 ```
 
 Leaf commands write structured text to stdout by default. Pass `--format json` for stable machine-readable output. In text output, epoch-style `*Date` fields render in local `YYYY-MM-DD HH:mm:ss` format, and escaped message bodies decode Polish characters while turning `<br>` tags into terminal line breaks. Errors follow the selected format on stderr and return a non-zero exit code. Download commands such as `lessons planned-attachment` and `auth photo` write the requested file and then report metadata describing the saved output.

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.3",
   "info": {
     "title": "Librus Synergia API (SDK-supported subset)",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "description": "Best-effort OpenAPI document generated from the SDK's supported child-scoped Synergia GET surface. Authentication starts on portal.librus.pl; this document covers the subsequent bearer-token calls against api.librus.pl/3.0."
   },
   "servers": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "librus-sdk",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "librus-sdk",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@valibot/to-json-schema": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librus-sdk",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "TypeScript SDK and CLI for the Librus family portal flow.",
   "author": "Andrey Koltsov",
   "repository": {


### PR DESCRIPTION
## Summary
- bump the package version from `0.3.0` to `0.3.1`
- move the terminal message readability fix from `Unreleased` into the `0.3.1` changelog section
- regenerate `openapi.json` so its published version matches the release

## Validation
- `npm run validate`
