### PR TITLE
[codex] Add security scanning and response docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,26 @@ jobs:
       - name: Validate release gates
         run: npm run validate
 
+  dependency-vulnerabilities:
+    name: Dependency vulnerability gate
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Fail on high or critical advisories
+        run: npm audit --audit-level=high
+
   trivy:
     name: Trivy scan
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,49 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  schedule:
+    - cron: "0 7 * * 1"
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - javascript-typescript
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ It intentionally does not reuse the legacy `synergia.librus.pl` HTML-scraping ap
 
 This implementation was inspired by [Mati365/librus-api](https://github.com/Mati365/librus-api/).
 
+## Security
+
+Report vulnerabilities privately as described in [`SECURITY.md`](./SECURITY.md).
+
+Never commit, log, or print real credentials, bearer tokens, cookies, or other
+secrets in source files, fixtures, examples, or documentation.
+
 ## Environment
 
 Set these variables before running the CLI:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,20 +4,28 @@
 
 | Version | Supported |
 | ------- | --------- |
-| 0.1.x   | Yes       |
-| < 0.1.0 | No        |
+| 0.3.x   | Yes       |
+| < 0.3.0 | No        |
 
 ## Reporting A Vulnerability
 
 Do not open a public GitHub issue for security-sensitive reports.
 
-Use GitHub's private vulnerability reporting flow if it is available for this
-repository. If you cannot use that flow, email `andrewkoltsov@gmail.com` with:
+Use GitHub's private vulnerability reporting flow as the primary reporting
+channel for this repository. If you cannot use that flow, email
+`andrewkoltsov@gmail.com` with:
 
 - a concise description of the issue
 - affected versions and environments
 - reproduction steps or a proof of concept
 - any suggested mitigation if you already have one
 
-I will acknowledge new reports within 3 business days and will coordinate a
-fix and disclosure timeline once the issue is confirmed.
+I will acknowledge new reports within 3 business days.
+
+Once an issue is confirmed, I will coordinate a fix and disclosure timeline.
+High-severity issues are targeted for remediation or mitigation within 30
+calendar days, and critical issues are expedited ahead of that target when
+feasible.
+
+When a security fix is publicly disclosed, the release notes will call it out
+explicitly.


### PR DESCRIPTION
## Summary

- add a dedicated CodeQL workflow for JavaScript and TypeScript
- add a blocking `npm audit --audit-level=high` job to CI while keeping the existing Trivy scan
- tighten the security reporting policy and add a short repo-level secret-handling note

## Why

This closes the planned security-scanning and vulnerability-response gaps without changing the TypeScript SDK or CLI behavior.

## Verification

- `npm run validate`
- `npm audit --audit-level=high`
- confirmed the repo secret-pattern searches return no hits
- confirmed a throwaway vulnerable package makes `npm audit --audit-level=high` exit non-zero
