### PR TITLE
[codex] Add contribution and maintenance docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,6 +6,11 @@ labels: ["bug"]
 assignees: []
 ---
 
+Review [`CONTRIBUTING.md`](../CONTRIBUTING.md) before filing.
+
+Do not use this template for security vulnerabilities. Follow
+[`SECURITY.md`](../SECURITY.md) instead.
+
 ## Summary
 
 Describe the problem in one or two sentences.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,6 +6,8 @@ labels: ["enhancement"]
 assignees: []
 ---
 
+Review [`CONTRIBUTING.md`](../CONTRIBUTING.md) before filing.
+
 ## Summary
 
 Describe the capability you want to add.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,6 @@
+Review [`CONTRIBUTING.md`](../CONTRIBUTING.md) for the branch workflow,
+required local checks, and when docs or changelog updates are expected.
+
 ## Summary
 
 - describe the user-visible change

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,68 @@
+# Code Of Conduct
+
+This project is committed to a respectful, safe, and welcoming community for
+everyone.
+
+## Our Commitment
+
+Contributors, maintainers, and participants should be able to take part in the
+project without harassment or exclusion. We expect interactions in project
+spaces to stay professional, constructive, and considerate of people with
+different backgrounds, identities, and experience levels.
+
+## Expected Behavior
+
+Examples of behavior that support a healthy community include:
+
+- showing empathy and patience
+- giving and receiving constructive feedback
+- assuming good intent while discussing technical disagreement
+- focusing criticism on ideas, code, and behavior rather than on people
+- respecting privacy and handling personal or sensitive information carefully
+
+## Unacceptable Behavior
+
+The following behavior is not acceptable in project spaces:
+
+- harassment, threats, or personal attacks
+- insulting, demeaning, or discriminatory language
+- deliberate intimidation, trolling, or sustained disruption
+- publishing other people's private information without permission
+- sexualized language or imagery, or unwelcome sexual attention
+- encouraging or participating in retaliation against someone who reports a concern
+
+## Maintainer Responsibilities
+
+Maintainers are responsible for setting and enforcing community standards in
+issues, pull requests, discussions, release notes, and other project-managed
+spaces. They may remove, edit, or reject comments, commits, code, issues, and
+other contributions that violate this Code of Conduct.
+
+## Scope
+
+This Code of Conduct applies within project spaces and when someone is
+representing the project in public spaces. Project spaces include the GitHub
+repository, issue tracker, pull requests, review threads, and any maintainer-run
+communication channels used for project work.
+
+## Reporting
+
+Report Code of Conduct concerns to `andrewkoltsov@gmail.com`. Include links,
+screenshots, or other context that helps explain what happened.
+
+Maintainers will review reports promptly and handle them as confidentially as
+practical. They may request more detail before deciding on a response.
+
+## Enforcement
+
+Possible responses include a private warning, content removal, temporary
+restrictions on participation, or a permanent ban from project spaces,
+depending on severity and pattern of behavior.
+
+People who report or participate in an investigation in good faith must not be
+retaliated against.
+
+## Attribution
+
+This document is adapted from the Contributor Covenant, version 2.1:
+https://www.contributor-covenant.org/version/2/1/code_of_conduct/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,92 @@
+# Contributing
+
+This repository accepts focused improvements to the SDK, CLI, documentation, and
+repository automation.
+
+## Before You Start
+
+- Use the issue tracker for reproducible bugs, feature requests, and scoped maintenance work.
+- Do not open public issues for security-sensitive reports. Follow
+  [`SECURITY.md`](./SECURITY.md) instead.
+- Keep changes small and reviewable. Split unrelated work into separate branches and pull requests.
+
+## Branch Workflow
+
+`master` is protected. Do not commit directly to `master`, and do not create new
+feature branches from a stale base branch.
+
+For work that should merge directly into `master`:
+
+```bash
+git checkout master
+git pull --ff-only origin master
+git worktree add ../librus-sdk-my-change -b codex/my-change master
+```
+
+Use a short descriptive branch name. Prefer one worktree per active feature so
+parallel changes do not interfere with each other.
+
+If a change intentionally depends on another in-flight feature branch, keep that
+dependency explicit and rebase or retarget the child branch once the parent
+lands.
+
+## Local Setup And Required Checks
+
+Install dependencies before running checks:
+
+```bash
+npm install
+```
+
+Run this full verification set before opening or updating a pull request unless
+you explain why a specific check was skipped:
+
+```bash
+npm run lint
+npm run format:check
+npm run build
+npm test
+npm run pack:check
+```
+
+You can run the CLI locally with:
+
+```bash
+npm run cli -- <command>
+```
+
+## Tests, Docs, And Changelog Expectations
+
+- Behavior changes should include focused Vitest coverage near the closest existing suite in `test/`.
+- Avoid tests that require live credentials or network access unless the change explicitly calls for manual verification.
+- User-facing SDK or CLI changes should update [`README.md`](./README.md).
+- User-facing SDK or CLI changes should also update [`CHANGELOG.md`](./CHANGELOG.md).
+- Documentation-only or workflow-only changes do not require a new npm release.
+
+## Pull Request Flow
+
+- Keep each pull request focused on one mergeable line of work.
+- Describe the user-visible change and any notable internal refactors.
+- List the verification you ran and note any intentionally skipped checks.
+- Call out required documentation or changelog updates when they apply.
+- Link the relevant issue when the pull request addresses tracked work.
+
+The repository includes a pull request template. Use it as the baseline summary
+for your change.
+
+## Maintainer Response Expectations
+
+Maintainer response times are best-effort, not guaranteed.
+
+- Bug reports: maintainers aim to acknowledge or triage new reports within 7 calendar days. If a report is incomplete, maintainers may ask for reproduction details, versions, or sanitized logs before taking action.
+- Enhancement requests: maintainers aim to acknowledge or triage new requests within 7 calendar days and may ask follow-up questions to confirm the problem, scope, or proposed interface.
+- Pull requests: maintainers aim to review new pull requests, or at least leave a status update, within 7 calendar days.
+- Stale work: issues and pull requests with no activity for 30 days may be marked stale. If there is still no reply after 14 more days, maintainers may close them until new context is available.
+
+Security-sensitive reports are handled outside the public issue tracker. Use
+[`SECURITY.md`](./SECURITY.md) for that process.
+
+## Community Standards
+
+By participating in this project, you agree to follow
+[`CODE_OF_CONDUCT.md`](./CODE_OF_CONDUCT.md).


### PR DESCRIPTION
## Summary

- add a root `CONTRIBUTING.md` covering branch workflow, required local checks, PR expectations, and maintainer response targets
- add a root `CODE_OF_CONDUCT.md` adapted from Contributor Covenant 2.1 with the existing maintainer contact
- point the bug, feature, and pull request templates at the new contribution documentation and route security reports to `SECURITY.md`

## Why

The repository already had CI, release docs, security guidance, and issue templates, but it did not document the expected contribution workflow or maintainer response policy in one discoverable place.

## Validation

- `npm run validate`
