### PR TITLE
[codex] Document public interface and release policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,17 @@
 
 Fresh TypeScript SDK and CLI for the Librus family portal flow.
 
-This project logs into `portal.librus.pl`, loads linked child accounts from `portal/api/v3/SynergiaAccounts`, and uses the selected child account's bearer token against `https://api.librus.pl/3.0`.
+This project logs into `portal.librus.pl`, loads linked child accounts from
+`portal/api/v3/SynergiaAccounts`, and uses the selected child account's bearer
+token against `https://api.librus.pl/3.0`.
 
-It intentionally does not reuse the legacy `synergia.librus.pl` HTML-scraping approach.
+It intentionally does not reuse the legacy `synergia.librus.pl` HTML-scraping
+approach.
 
 ## Acknowledgements
 
-This implementation was inspired by [Mati365/librus-api](https://github.com/Mati365/librus-api/).
+This implementation was inspired by
+[Mati365/librus-api](https://github.com/Mati365/librus-api/).
 
 ## Security
 
@@ -16,17 +20,6 @@ Report vulnerabilities privately as described in [`SECURITY.md`](./SECURITY.md).
 
 Never commit, log, or print real credentials, bearer tokens, cookies, or other
 secrets in source files, fixtures, examples, or documentation.
-
-## Environment
-
-Set these variables before running the CLI:
-
-```bash
-LIBRUS_PORTAL_EMAIL=you@example.com
-LIBRUS_PORTAL_PASSWORD=your-password
-```
-
-The SDK also accepts the older aliases `LIBRUS_EMAIL` and `LIBRUS_PASSWORD` as a compatibility fallback for the current local `.env`.
 
 ## Install
 
@@ -44,9 +37,279 @@ npx librus children list
 npx librus grades list --child <id-or-login>
 ```
 
-The package also ships a generated [`openapi.json`](./openapi.json) for the SDK-supported child-scoped `https://api.librus.pl/3.0` surface, so non-TypeScript consumers can generate clients in other languages. It is also exported as `librus-sdk/openapi.json`.
+The package also ships a generated [`openapi.json`](./openapi.json) for the
+SDK-supported child-scoped `https://api.librus.pl/3.0` surface, so non-TypeScript
+consumers can generate clients in other languages. It is also exported as
+`librus-sdk/openapi.json`.
 
-## Local development
+## Public Interface
+
+This README is the canonical public-interface reference for the npm package and
+CLI published from this repository.
+
+### Environment
+
+`LibrusSession.fromEnv()` and the CLI read credentials from these variables:
+
+| Variable                 | Required | Purpose                                            |
+| ------------------------ | -------- | -------------------------------------------------- |
+| `LIBRUS_PORTAL_EMAIL`    | Yes      | Portal login email used for `portal.librus.pl`.    |
+| `LIBRUS_PORTAL_PASSWORD` | Yes      | Portal login password used for `portal.librus.pl`. |
+| `LIBRUS_EMAIL`           | Fallback | Compatibility alias for `LIBRUS_PORTAL_EMAIL`.     |
+| `LIBRUS_PASSWORD`        | Fallback | Compatibility alias for `LIBRUS_PORTAL_PASSWORD`.  |
+
+### Top-Level SDK Entry Points
+
+Import from the package root:
+
+```ts
+import {
+  LibrusSession,
+  PortalClient,
+  SynergiaApiClient,
+  generateOpenApiDocument,
+  LibrusSdkError,
+} from "librus-sdk";
+```
+
+| Export                    | Purpose                                                                                                                               |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `LibrusSession`           | Recommended high-level entry point. Handles login, linked-child discovery, child selection, and creation of child-scoped API clients. |
+| `PortalClient`            | Lower-level portal session client for `portal.librus.pl` login, `/Me`, and `/SynergiaAccounts`.                                       |
+| `SynergiaApiClient`       | Child-scoped GET client for the supported `https://api.librus.pl/3.0` surface when you already have a bearer token.                   |
+| `generateOpenApiDocument` | Generates the shipped OpenAPI document for the supported child-scoped GET subset.                                                     |
+
+Recommended session flow:
+
+```ts
+import { LibrusSession } from "librus-sdk";
+
+const session = LibrusSession.fromEnv();
+const children = await session.listChildren();
+const client = await session.forChild(children[0]);
+const grades = await client.getGrades();
+console.log(grades);
+```
+
+Current high-level methods on `LibrusSession`:
+
+- `LibrusSession.fromEnv(env?)`
+- `new LibrusSession({ credentials, portalClient?, portalClientOptions?, synergiaClientOptions? })`
+- `login()`
+- `getPortalMe()`
+- `getSynergiaAccounts()`
+- `listChildren()`
+- `resolveChild(selector)`
+- `forChild(selectorOrChild)`
+
+Current methods on `PortalClient`:
+
+- `new PortalClient(options?)`
+- `login(credentials)`
+- `getMe()`
+- `getSynergiaAccounts()`
+- `isLoggedIn()`
+
+`SynergiaApiClient` exposes explicit child-scoped read methods grouped by
+endpoint family rather than raw route strings:
+
+| Domain                           | Methods exposed today                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Profile                          | `getMe()`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| Grades                           | `getGrades()`, `getGradeAverages(subjectId?)`, `getGradeCategories()`, `getGradeComments()`, `getBehaviourGrades()`, `getBehaviourGradeTypes()`, `getBehaviourGradePoints()`, `getBehaviourPointCategories()`, `getBehaviourPointComments()`, `getBehaviourSystemProposal()`, `getDescriptiveGrades()`, `getDescriptiveGradeComments()`, `getDescriptiveGradeSkills()`, `getDescriptiveGradeText(subjectId)`, `getDescriptiveGradeTextCategories()`, `getDescriptiveTextGrades()`, `getDescriptiveTextGradeSkills()`, `getPointGrades(subjectId?)`, `getPointGradeAverages(subjectId?)`, `getPointGradeCategories()`, `getPointGradeComments()`, `getTextGrades()` |
+| Attendance                       | `getAttendances()`, `getAttendanceTypes()`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| Timetable                        | `getTimetableWeek(weekStart)`, `getTimetableDay(day)`, `getTimetableEntry(id)`, `getCalendars()`, `getClassFreeDays()`, `getClassFreeDayTypes()`, `getSchoolFreeDays()`, `getTeacherFreeDays()`, `getSubstitution(id)`, `getVirtualClasses()`                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| Lessons                          | `listLessons()`, `getLesson(id)`, `listPlannedLessons()`, `getPlannedLesson(id)`, `getPlannedLessonAttachment(id)`, `listRealizations()`, `getRealization(id)`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| Homework                         | `getHomeWorks()`, `getHomeworkAssignments()`, `getHomeworkAssignmentAttachment(id)`, `getHomeworkCategories()`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| Messages                         | `listMessages(options?)`, `getMessage(id)`, `getUnreadMessages()`, `listMessagesForUser(userId)`, `listMessageReceiverGroups()`, `getMessageReceiverGroup(id)`, `getMessageAttachment(id)`                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| Announcements and notes          | `listSchoolNotices()`, `getSchoolNotice(id)`, `listNotes()`, `getNote(id)`, `listNoteCategories()`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| School metadata                  | `getSchool()`, `getSchoolById(id)`, `getClass()`, `getClassroom(id)`, `listSubjects()`, `getSubject(id)`, `listUsers()`, `getUser(id)`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| Notifications and justifications | `getLuckyNumber(forDay?)`, `getNotificationCenter()`, `getPushConfigurations()`, `listJustifications(options?)`, `getJustification(id)`, `listParentTeacherConferences()`, `getSystemData()`                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| Auth reads                       | `listAuthPhotos()`, `getAuthPhoto(id)`, `getAuthUserInfo(id)`, `getAuthTokenInfo()`, `getAuthClassroom(id)`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+
+Attachment-style methods such as `getHomeworkAssignmentAttachment(id)`,
+`getMessageAttachment(id)`, and `getPlannedLessonAttachment(id)` return
+`SynergiaBinaryResult` with `{ data, contentType, contentDisposition }`.
+
+`getAuthPhoto(id)` mirrors the live API and returns JSON with the photo payload
+under `data.photo`, including base64 content in `data.photo.content`. The CLI
+`auth photo --output <path>` command decodes that content before writing the
+file.
+
+`HomeWork.LessonNo` mirrors the live Librus payload and may be `string`,
+`number`, or `null`. `HomeWork.Subject` may be omitted entirely or returned as
+`null`.
+
+### Constructor And Helper Option Shapes
+
+These tables describe the option objects currently accepted by the exported
+constructors and helpers. The interface names are the current source names used
+in the generated `.d.ts`, but the package documents the accepted property shapes
+here rather than promising every helper type as a named top-level export.
+
+`LibrusSession` constructor options (`LibrusSessionOptions`):
+
+| Property                | Required | Meaning                                                                              |
+| ----------------------- | -------- | ------------------------------------------------------------------------------------ |
+| `credentials`           | Yes      | Portal credentials object with `email` and `password`.                               |
+| `portalClient`          | No       | Reuse an existing `PortalClient` instance instead of constructing one internally.    |
+| `portalClientOptions`   | No       | Passed to the internally created `PortalClient` when `portalClient` is not supplied. |
+| `synergiaClientOptions` | No       | Passed to `SynergiaApiClient` instances created by `forChild(...)`.                  |
+
+`PortalClient` constructor options (`PortalClientOptions`):
+
+| Property           | Required | Meaning                                                                             |
+| ------------------ | -------- | ----------------------------------------------------------------------------------- |
+| `fetch`            | No       | Custom fetch implementation. The client wraps it in cookie-backed session handling. |
+| `portalBaseUrl`    | No       | Portal origin. Defaults to `https://portal.librus.pl`.                              |
+| `portalApiBaseUrl` | No       | Portal API base URL. Defaults to `${portalBaseUrl}/api/v3`.                         |
+| `loginPath`        | No       | Login page path. Defaults to `/konto-librus/login`.                                 |
+| `loginActionPath`  | No       | Login form submission path. Defaults to `/konto-librus/login/action`.               |
+
+`SynergiaApiClient` constructor options (`SynergiaApiClientOptions`):
+
+| Property     | Required | Meaning                                                         |
+| ------------ | -------- | --------------------------------------------------------------- |
+| `fetch`      | No       | Custom fetch implementation for child-scoped API requests.      |
+| `apiBaseUrl` | No       | Synergia API base URL. Defaults to `https://api.librus.pl/3.0`. |
+
+`generateOpenApiDocument()` options (`GenerateOpenApiDocumentOptions`):
+
+| Property    | Required | Meaning                                                                                                          |
+| ----------- | -------- | ---------------------------------------------------------------------------------------------------------------- |
+| `title`     | No       | Overrides the generated OpenAPI `info.title`.                                                                    |
+| `version`   | No       | Overrides the generated OpenAPI `info.version`. Pass the package version when generating a publishable document. |
+| `serverUrl` | No       | Overrides the default server URL `https://api.librus.pl/3.0`.                                                    |
+
+### Public Types And Errors
+
+In addition to the top-level classes above, the package root re-exports the
+model and error modules under `src/sdk/models/`.
+
+| Category                       | Public surface                                                                                                                                        |
+| ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Portal and child-account types | `PortalCredentials`, `PortalMe`, `ChildAccount`, `SynergiaAccountsResponse`                                                                           |
+| Shared response helpers        | `ApiRef`, `SynergiaBinaryResult`, other common helper interfaces used by SDK responses                                                                |
+| Synergia response models       | Response and entity interfaces for the supported child-scoped API surface under the `synergia` model barrels                                          |
+| Error classes                  | `LibrusSdkError`, `LibrusApiError`, `LibrusAuthenticationError`, `LibrusConfigurationError`, `LibrusPortalPageError`, `LibrusResponseValidationError` |
+
+### CLI Surface
+
+Root CLI commands:
+
+- `librus --help`
+- `librus --version`
+
+Every leaf command supports `--format <text|json>`. Child-scoped commands use
+`--child <id-or-login>` to select the linked child account by numeric id or by
+login.
+
+| Family           | Subcommands                                                                                                 | Extra selectors and flags                                                                                                          |
+| ---------------- | ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `children`       | `list`                                                                                                      | No child selector.                                                                                                                 |
+| `me`             | root command                                                                                                | `--child`.                                                                                                                         |
+| `grades`         | `list`                                                                                                      | `--child`.                                                                                                                         |
+| `attendance`     | `list`                                                                                                      | `--child`.                                                                                                                         |
+| `homework`       | `list`                                                                                                      | `--child`.                                                                                                                         |
+| `messages`       | `list`, `get`, `unread`                                                                                     | `list` supports `--after-id <id>`; `get` requires `--id <id>`.                                                                     |
+| `timetable`      | `week`, `day`, `entry`                                                                                      | `week` requires `--week-start <YYYY-MM-DD>`; `day` requires `--day <YYYY-MM-DD>`; `entry` requires `--id <id>`.                    |
+| `announcements`  | `list`, `get`                                                                                               | `get` requires `--id <id>`.                                                                                                        |
+| `notes`          | `list`, `get`                                                                                               | `get` requires `--id <id>`.                                                                                                        |
+| `lessons`        | `list`, `get`, `planned-list`, `planned-get`, `planned-attachment`, `realizations-list`, `realizations-get` | `get`, `planned-get`, and `realizations-get` require `--id <id>`; `planned-attachment` requires `--id <id>` and `--output <path>`. |
+| `lucky-number`   | `get`                                                                                                       | Optional `--for-day <YYYY-MM-DD>`.                                                                                                 |
+| `notifications`  | `center`, `push-configurations`                                                                             | `--child`.                                                                                                                         |
+| `justifications` | `list`, `get`, `conferences`, `system-data`                                                                 | `list` supports `--date-from <YYYY-MM-DD>`; `get` requires `--id <id>`.                                                            |
+| `auth`           | `photos`, `photo`, `user-info`, `token-info`, `classroom`                                                   | `photo` requires `--id <id>` and `--output <path>`; `user-info` and `classroom` require `--id <id>`.                               |
+
+### CLI Output Contract
+
+- Human-readable text is the default stdout format for successful commands.
+- `--format json` is the stable machine-readable interface for automation.
+- Errors are written to stderr and follow the selected output format.
+- Non-successful commands return a non-zero exit code.
+- `children list` JSON output is `{ lastModification, children }`.
+- Child-scoped read commands emit `{ child, data }` in JSON output.
+- Download commands such as `lessons planned-attachment` and `auth photo`
+  write the requested file first, then report saved-file metadata instead of raw
+  bytes. JSON output keeps the same `{ child, data }` envelope, where `data`
+  contains `{ path, bytes, contentType, contentDisposition }`.
+- Text output is meant for terminal readability. It is not a stable parsing
+  contract.
+- Current text rendering normalizes epoch-style `*Date` fields to local
+  `YYYY-MM-DD HH:mm:ss` values and turns escaped message bodies and `<br>` tags
+  into readable terminal text.
+
+### Error-Code Contract
+
+Consumers should branch on `error.code`, not on the free-form message text.
+
+JSON stderr shape is stable:
+
+```json
+{
+  "error": {
+    "code": "CONFIGURATION_ERROR",
+    "message": "Missing portal credentials.",
+    "details": {}
+  }
+}
+```
+
+Contract:
+
+- `error.code` is the stable discriminator for machine handling.
+- `error.message` is human-facing and may be refined without changing the error
+  category.
+- `error.details` is optional and extensible. Callers should ignore unknown
+  keys.
+- Existing documented codes stay stable.
+- Future SDK features may add new codes without changing the overall JSON error
+  envelope.
+
+Current codes emitted by the SDK and CLI:
+
+| Code                         | Meaning                                                                    |
+| ---------------------------- | -------------------------------------------------------------------------- |
+| `CONFIGURATION_ERROR`        | Required credentials or other local configuration are missing or invalid.  |
+| `AUTHENTICATION_FAILED`      | Portal login or post-login verification failed.                            |
+| `PORTAL_LOGIN_PAGE_INVALID`  | The portal login page no longer matches the expected CSRF-token structure. |
+| `API_REQUEST_FAILED`         | A portal or Synergia request failed with a non-maintenance HTTP error.     |
+| `SERVICE_MAINTENANCE`        | The Synergia API reported maintenance mode.                                |
+| `RESPONSE_VALIDATION_FAILED` | The live payload no longer matches the validated SDK schema.               |
+| `CHILD_NOT_FOUND`            | No linked child account matched the provided selector.                     |
+| `AMBIGUOUS_CHILD`            | More than one linked child account matched the provided selector.          |
+| `CLI_USAGE_ERROR`            | The CLI arguments were invalid, incomplete, or used unsupported values.    |
+| `INTERNAL_ERROR`             | Unexpected non-SDK error wrapper used by the CLI fallback path.            |
+
+### OpenAPI
+
+`openapi.json` is generated from the SDK's supported Synergia GET endpoints and
+the shared valibot response schemas. The document is best-effort and
+intentionally covers only the child-scoped `api.librus.pl/3.0` requests, not
+the `portal.librus.pl` login flow.
+
+Regenerate or verify the file locally with:
+
+```bash
+npm run openapi:generate
+npm run openapi:check
+```
+
+You can also generate the document programmatically:
+
+```ts
+import { generateOpenApiDocument } from "librus-sdk";
+
+const openApi = generateOpenApiDocument({ version: "0.3.1" });
+```
+
+### Release And Versioning Policy
+
+Repository release policy, SemVer rules, tag naming, changelog-backed release
+notes, and badge-homepage guidance are documented in
+[`docs/releasing.md`](./docs/releasing.md).
+
+## Local Development
 
 ```bash
 npm install
@@ -75,11 +338,10 @@ npm run cli -- justifications conferences --child <id-or-login>
 npm run cli -- auth photo --child <id-or-login> --id <photo-id> --output ./photo.jpg
 ```
 
-`HomeWork.LessonNo` mirrors the live Librus payload and may be `string`, `number`, or `null`. `HomeWork.Subject` may be omitted entirely or returned as `null`.
+## Live Integration Tests
 
-## Live integration tests
-
-This repo also includes optional live integration tests for the built SDK and CLI artifacts in `dist`.
+This repo also includes optional live integration tests for the built SDK and
+CLI artifacts in `dist`.
 
 They are intended for local manual verification only:
 
@@ -107,46 +369,10 @@ npm run report:integration:sdk
 npm run report:integration:cli
 ```
 
-To limit the live run to specific children, set `LIBRUS_TEST_CHILDREN` as a comma-separated list of child ids or logins:
+To limit the live run to specific children, set `LIBRUS_TEST_CHILDREN` as a
+comma-separated list of child ids or logins:
 
 ```bash
 LIBRUS_TEST_CHILDREN=7147345 npm run test:integration
 LIBRUS_TEST_CHILDREN=7147345,child-login npm run report:integration
 ```
-
-## SDK usage
-
-```ts
-import { LibrusSession } from "librus-sdk";
-
-const session = LibrusSession.fromEnv();
-const children = await session.listChildren();
-console.log(children);
-```
-
-`await session.forChild(child).getHomeWorks()` preserves the API's `HomeWork.LessonNo` value as `string`, `number`, or `null`, and leaves `HomeWork.Subject` absent when the API omits it.
-
-The SDK also exposes widget-derived GET coverage for timetable, messages, announcements, notes, school/class metadata, lessons, lucky number, notification settings, justifications, parent-teacher conferences, system data, and auth-related reads. Attachment methods such as `getHomeworkAssignmentAttachment(id)`, `getMessageAttachment(id)`, and `getPlannedLessonAttachment(id)` return `{ data, contentType, contentDisposition }`.
-
-`getAuthPhoto(id)` mirrors the live API and returns JSON with the photo payload under `data.photo`, including base64 content in `data.photo.content`. The CLI `auth photo --output <path>` command decodes that content to a file and reports the saved-file metadata in text by default or JSON with `--format json`.
-
-## OpenAPI
-
-`openapi.json` is generated from the SDK's supported Synergia GET endpoints and the shared valibot response schemas. The document is best-effort and intentionally covers only the child-scoped `api.librus.pl/3.0` requests, not the `portal.librus.pl` login flow.
-
-Regenerate or verify the file locally with:
-
-```bash
-npm run openapi:generate
-npm run openapi:check
-```
-
-You can also generate the document programmatically:
-
-```ts
-import { generateOpenApiDocument } from "librus-sdk";
-
-const openApi = generateOpenApiDocument({ version: "0.3.1" });
-```
-
-Leaf commands write structured text to stdout by default. Pass `--format json` for stable machine-readable output. In text output, epoch-style `*Date` fields render in local `YYYY-MM-DD HH:mm:ss` format, and escaped message bodies decode Polish characters while turning `<br>` tags into terminal line breaks. Errors follow the selected format on stderr and return a non-zero exit code. Download commands such as `lessons planned-attachment` and `auth photo` write the requested file and then report metadata describing the saved output.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,9 +1,54 @@
 # Releasing
 
-This repository publishes `librus-sdk` to npm from GitHub Actions using npm trusted
-publishing.
+This repository publishes `librus-sdk` to npm from GitHub Actions using npm
+trusted publishing.
 
-## One-time setup
+## Versioning Policy
+
+- `package.json` is the source of truth for the published package version.
+- Releases follow Semantic Versioning (`MAJOR.MINOR.PATCH`).
+- Documentation-only, workflow-only, and badge-only changes do not require a
+  new npm release unless they accompany an actual public SDK or CLI behavior
+  change.
+
+## Tag And Branch Policy
+
+- Releases are triggered by annotated `vX.Y.Z` tags.
+- The tag name must exactly match the version in `package.json`.
+- The tagged commit must be reachable from `origin/master`.
+- The current repository history follows this convention with tags such as
+  `v0.2.0`, `v0.2.1`, `v0.2.2`, `v0.3.0`, and `v0.3.1`.
+
+Example:
+
+```bash
+git checkout master
+git pull --ff-only origin master
+git tag -a v0.3.1 -m "v0.3.1"
+git push origin v0.3.1
+```
+
+The release workflow in
+[`../.github/workflows/release.yml`](../.github/workflows/release.yml) will:
+
+- confirm the pushed tag matches `package.json`
+- require the tagged commit to be reachable from `origin/master`
+- publish to npm if that version is not already present
+- create the GitHub Release from the matching `CHANGELOG.md` section
+
+## Release Notes Policy
+
+- `CHANGELOG.md` is the source of truth for release notes.
+- Before tagging a release, move notes from `Unreleased` into a new versioned
+  `## [X.Y.Z] - YYYY-MM-DD` section.
+- GitHub Release notes are generated from the matching changelog section by
+  `scripts/extract-release-notes.mjs`.
+- The matching changelog section must exist and must not be empty, or release
+  note generation fails.
+- When a security fix is publicly disclosed, call it out explicitly in the
+  release notes for the affected version.
+
+## One-Time Setup
 
 Configure npm trusted publishing for package `librus-sdk` with:
 
@@ -13,29 +58,21 @@ Configure npm trusted publishing for package `librus-sdk` with:
 Do not use GitHub Packages for this repository. The package remains unscoped and
 continues to publish to npmjs only.
 
-## Release checklist
+## Release Checklist
 
 1. Update `package.json` to the release version.
 2. Move the release notes from `Unreleased` into a new versioned section in
    `CHANGELOG.md`.
 3. Merge the release commit to `master`.
 4. Refresh your local `master` branch.
-5. Create an annotated tag for the release version.
+5. Create an annotated tag `vX.Y.Z` for the same version.
 6. Push the tag to GitHub.
-7. Verify that the release workflow publishes the package and creates the GitHub Release.
+7. Verify that the release workflow publishes the package and creates the
+   GitHub Release.
 
-Example:
+## Homepage Value For Badge Evidence
 
-```bash
-git checkout master
-git pull --ff-only origin master
-git tag -a v0.1.1 -m "v0.1.1"
-git push origin v0.1.1
-```
+For consistency with `package.json`, use this project homepage value in badge or
+Best Practices forms until the package metadata changes:
 
-The release workflow will:
-
-- confirm the tag matches `package.json`
-- require the tagged commit to be reachable from `origin/master`
-- publish to npm if that version is not already present
-- create the GitHub Release from the matching `CHANGELOG.md` section
+`https://github.com/andrewkoltsov/librus-sdk#readme`


### PR DESCRIPTION
## Summary

Document the current public SDK and CLI surface in the README and make the release/versioning policy explicit in-repo.

## What changed

- made `README.md` the canonical public-interface reference for the npm package and CLI
- documented top-level SDK entrypoints, constructor/helper option shapes, CLI families, output contracts, and stable error-code guidance
- expanded `docs/releasing.md` with SemVer, annotated `vX.Y.Z` tags, changelog-backed release notes, security-fix callouts, and the homepage value used for badge evidence

## Why

The repository already exposes a real public SDK and CLI, but the interface and versioning expectations were spread across code, tests, and workflows. This change makes those answers available directly from repo documentation.

## Validation

- `npx prettier --check README.md docs/releasing.md`
- `npm test`
