### PR TITLE
[codex] prepare 0.4.0 runtime hardening release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-04-02
+
 ### Added
 
 - Release automation now verifies the published npm package still exposes

--- a/README.md
+++ b/README.md
@@ -313,10 +313,12 @@ Use the auth helper directly when you need to compare child tokens:
 npx librus auth token-info --child <id-or-login>
 ```
 
-For timeout handling, SDK and CLI timeout failures emit `NETWORK_TIMEOUT` with
-secret-safe `details` shaped like `{ endpoint, timeoutMs }`. The endpoint is
-the request URL only; credentials, bearer tokens, and cookie values are not
-included.
+For timeout handling, the SDK throws `LibrusNetworkTimeoutError`, and the CLI
+writes the same `NETWORK_TIMEOUT` failure to stderr. With `--format json`,
+stderr includes secret-safe `details` shaped like `{ endpoint, timeoutMs }`.
+With `--format text`, stderr still includes the same stable code and the
+human-facing timeout message. The endpoint is the request URL only;
+credentials, bearer tokens, and cookie values are not included.
 
 ### OpenAPI
 
@@ -337,7 +339,7 @@ You can also generate the document programmatically:
 ```ts
 import { generateOpenApiDocument } from "librus-sdk";
 
-const openApi = generateOpenApiDocument({ version: "0.3.2" });
+const openApi = generateOpenApiDocument({ version: "0.4.0" });
 ```
 
 ### Release And Versioning Policy

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -17,15 +17,15 @@ trusted publishing.
 - The tag name must exactly match the version in `package.json`.
 - The tagged commit must be reachable from `origin/master`.
 - The current repository history follows this convention with tags such as
-  `v0.2.0`, `v0.2.1`, `v0.2.2`, `v0.3.0`, and `v0.3.1`.
+  `v0.2.0`, `v0.2.1`, `v0.2.2`, `v0.3.0`, `v0.3.1`, and `v0.3.2`.
 
 Example:
 
 ```bash
 git checkout master
 git pull --ff-only origin master
-git tag -a v0.3.1 -m "v0.3.1"
-git push origin v0.3.1
+git tag -a v0.4.0 -m "v0.4.0"
+git push origin v0.4.0
 ```
 
 The release workflow in
@@ -49,6 +49,9 @@ The release workflow in
   note generation fails.
 - When a security fix is publicly disclosed, call it out explicitly in the
   release notes for the affected version.
+- Call out public runtime-hardening and other operational behavior changes that
+  affect configuration or failure handling, such as request timeouts or
+  secret-safe error-contract changes, even when they are not security fixes.
 
 ## One-Time Setup
 

--- a/docs/verification-2026-04-02.md
+++ b/docs/verification-2026-04-02.md
@@ -1,0 +1,63 @@
+# Verification Notes
+
+Date: 2026-04-02
+
+All notes below are sanitized:
+
+- no raw credentials
+- no raw bearer tokens
+- no child names
+
+## Local checks
+
+Successful commands:
+
+```bash
+npm run validate
+node ./scripts/extract-release-notes.mjs 0.4.0
+npx vitest run test/portal-client.test.ts test/synergia-client.test.ts test/librus-session.test.ts test/cli.test.ts -t 'timeout|LIBRUS_TIMEOUT_MS'
+```
+
+Outcome:
+
+- `npm run validate` succeeded with `272` tests passing across `18` files
+- coverage from `npm run validate` reported:
+  - statements: `90.97%`
+  - branches: `83.64%`
+  - functions: `93.17%`
+  - lines: `91.09%`
+- `node ./scripts/extract-release-notes.mjs 0.4.0` succeeded and returned the
+  `requestTimeoutMs`, `LIBRUS_TIMEOUT_MS`, and `NETWORK_TIMEOUT` release notes
+- focused timeout and environment checks passed: `7` tests matched, `7` passed
+
+## Timeout behavior
+
+Deterministic timeout coverage now confirms the implemented public contract:
+
+- `PortalClient` times out a hanging login-page request with `NETWORK_TIMEOUT`
+  and secret-safe `{ endpoint, timeoutMs }` details
+- `SynergiaApiClient` times out a hanging child-scoped request with the same
+  stable error code and details shape
+- CLI stderr keeps the timeout failure secret-safe in both `--format json` and
+  text output
+- `LibrusSession.fromEnv()` reads `LIBRUS_TIMEOUT_MS` and rejects invalid values
+  with `CONFIGURATION_ERROR` before making requests
+
+Observed timeout contract:
+
+- code: `NETWORK_TIMEOUT`
+- message shape: `Librus request timed out after <timeoutMs>ms.`
+- details shape: `{ endpoint, timeoutMs }`
+- secrets excluded from the error payload: portal password, bearer token, and
+  authorization header values
+
+## Documentation cross-check
+
+The current public documentation now matches the implemented timeout surface:
+
+- `README.md` documents `LIBRUS_TIMEOUT_MS`
+- `README.md` documents `requestTimeoutMs` on `LibrusSession`,
+  `PortalClient`, and `SynergiaApiClient`
+- timeout defaults remain `30000` milliseconds when no override is supplied
+- CLI timeout behavior is described as stderr output in both `text` and `json`
+  formats

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.3",
   "info": {
     "title": "Librus Synergia API (SDK-supported subset)",
-    "version": "0.3.2",
+    "version": "0.4.0",
     "description": "Best-effort OpenAPI document generated from the SDK's supported child-scoped Synergia GET surface. Authentication starts on portal.librus.pl; this document covers the subsequent bearer-token calls against api.librus.pl/3.0."
   },
   "servers": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "librus-sdk",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "librus-sdk",
-      "version": "0.3.2",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@valibot/to-json-schema": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librus-sdk",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "TypeScript SDK and CLI for the Librus family portal flow.",
   "author": "Andrey Koltsov",
   "repository": {


### PR DESCRIPTION
## Summary
- prepare the `0.4.0` runtime-hardening release metadata and docs
- document the implemented timeout contract for SDK and CLI consumers
- add a new dated verification note and regenerate `openapi.json` for the bumped version

## Why
Task 11 is the non-TypeScript follow-up to the timeout work that already landed in code. The remaining work is release prep: align the public docs with the implemented timeout surface, move the unreleased notes into a `0.4.0` changelog section, and record fresh verification evidence without rewriting the older pre-timeout note.

## What changed
- bumped the package version to `0.4.0` in package metadata
- updated the README timeout wording to call out CLI stderr behavior for both `text` and `json` formats
- moved the current unreleased notes into the `0.4.0` changelog entry
- updated release docs to call out runtime-hardening and operational changes in release notes
- added `docs/verification-2026-04-02.md` with sanitized validation and timeout-contract evidence
- regenerated `openapi.json` so its version matches the release

## Validation
- `npm run validate`
- `node ./scripts/extract-release-notes.mjs 0.4.0`
- `npx vitest run test/portal-client.test.ts test/synergia-client.test.ts test/librus-session.test.ts test/cli.test.ts -t 'timeout|LIBRUS_TIMEOUT_MS'`
