### PR TITLE
[codex] Harden Scorecard workflow integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ on:
 
 permissions:
   contents: read
-  security-events: write
 
 jobs:
   test:
@@ -20,10 +19,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 20
           cache: npm
@@ -40,10 +39,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 20
           cache: npm
@@ -57,12 +56,15 @@ jobs:
   trivy:
     name: Trivy scan (informational)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Run Trivy vulnerability and secret scan
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: fs
           scan-ref: .
@@ -70,7 +72,7 @@ jobs:
           output: trivy-results.sarif
 
       - name: Upload Trivy scan results
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@d4b3ca9fa7f69d38bfcd667bdc45bc373d16277e # v4
         if: always()
         with:
           sarif_file: trivy-results.sarif

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,14 +10,16 @@ on:
   workflow_dispatch:
 
 permissions:
-  actions: read
   contents: read
-  security-events: write
 
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     strategy:
       fail-fast: false
       matrix:
@@ -26,16 +28,16 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@d4b3ca9fa7f69d38bfcd667bdc45bc373d16277e # v4
         with:
           languages: ${{ matrix.language }}
           build-mode: none
 
       - name: Set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 20
           cache: npm
@@ -44,6 +46,6 @@ jobs:
         run: npm ci
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@d4b3ca9fa7f69d38bfcd667bdc45bc373d16277e # v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,7 @@ on:
       - "v*.*.*"
 
 permissions:
-  contents: write
-  id-token: write
+  contents: read
 
 concurrency:
   group: release-${{ github.ref }}
@@ -17,15 +16,18 @@ jobs:
   publish:
     name: Publish release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 24
           cache: npm

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -20,12 +20,12 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
 
       - name: Run OpenSSF Scorecard analysis
-        uses: ossf/scorecard-action@v2.4.3
+        uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3
         with:
           results_file: scorecard-results.sarif
           results_format: sarif
@@ -33,7 +33,7 @@ jobs:
 
       - name: Upload Scorecard artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: scorecard-results
           path: scorecard-results.sarif
@@ -41,6 +41,6 @@ jobs:
 
       - name: Upload Scorecard results to code scanning
         if: always()
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@d4b3ca9fa7f69d38bfcd667bdc45bc373d16277e # v4
         with:
           sarif_file: scorecard-results.sarif

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- README now exposes the public OpenSSF Scorecard badge and report link for the
+  repository security posture.
+
+### Changed
+
+- GitHub Actions workflows now pin third-party and GitHub-hosted actions by
+  commit hash, and write-scoped workflow token permissions are limited to the
+  jobs that need them.
+
 ## [0.4.0] - 2026-04-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # librus-sdk
 
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/andrewkoltsov/librus-sdk/badge)](https://scorecard.dev/viewer/?uri=github.com/andrewkoltsov/librus-sdk)
+
 Fresh TypeScript SDK and CLI for the Librus family portal flow.
 
 This project logs into `portal.librus.pl`, loads linked child accounts from
@@ -20,6 +22,11 @@ Report vulnerabilities privately as described in [`SECURITY.md`](./SECURITY.md).
 
 Never commit, log, or print real credentials, bearer tokens, cookies, or other
 secrets in source files, fixtures, examples, or documentation.
+
+The repository also publishes a weekly
+[OpenSSF Scorecard report](https://scorecard.dev/viewer/?uri=github.com/andrewkoltsov/librus-sdk)
+from GitHub Actions so maintainers can track workflow hardening and other
+supply-chain signals over time.
 
 ## Install
 


### PR DESCRIPTION
## Summary

- add the public OpenSSF Scorecard badge and report link to the README
- pin GitHub Actions references to immutable commit SHAs
- scope write-level workflow permissions down to the jobs that actually need them
- record the repository-facing change in the changelog

## Why

The repository already had a Scorecard workflow, but the current Scorecard report was still penalizing the project for unpinned workflow dependencies and broad workflow token scope. This PR makes the integration visible to users and addresses the workflow hardening issues that can be fixed in-repo.

## Validation

- `npm run lint`
- `npm run build`
- `npm run test:coverage`
- `npm run pack:check`
- `npx prettier --check .github/workflows/ci.yml .github/workflows/codeql.yml .github/workflows/release.yml .github/workflows/scorecard.yml README.md CHANGELOG.md`

## Notes

- `npm run validate` in the local checkout is blocked by an unrelated untracked `.tasks/README.md` formatting issue that is not part of this PR and will not exist in GitHub Actions.
- The latest public Scorecard run on `master` predates this branch, so the score should be re-checked after merge or after a run against this branch.
