### PR TITLE
[codex] Improve remaining Scorecard drivers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,14 @@ updates:
         update-types:
           - minor
           - patch
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:30"
+      timezone: Europe/Warsaw
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - github-actions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
           output: trivy-results.sarif
 
       - name: Upload Trivy scan results
-        uses: github/codeql-action/upload-sarif@d4b3ca9fa7f69d38bfcd667bdc45bc373d16277e # v4
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4
         if: always()
         with:
           sarif_file: trivy-results.sarif

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@d4b3ca9fa7f69d38bfcd667bdc45bc373d16277e # v4
+        uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4
         with:
           languages: ${{ matrix.language }}
           build-mode: none
@@ -46,6 +46,6 @@ jobs:
         run: npm ci
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@d4b3ca9fa7f69d38bfcd667bdc45bc373d16277e # v4
+        uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -25,7 +25,7 @@ jobs:
           persist-credentials: false
 
       - name: Run OpenSSF Scorecard analysis
-        uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: scorecard-results.sarif
           results_format: sarif
@@ -41,6 +41,6 @@ jobs:
 
       - name: Upload Scorecard results to code scanning
         if: always()
-        uses: github/codeql-action/upload-sarif@d4b3ca9fa7f69d38bfcd667bdc45bc373d16277e # v4
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4
         with:
           sarif_file: scorecard-results.sarif

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - GitHub Actions workflows now pin third-party and GitHub-hosted actions by
   commit hash, and write-scoped workflow token permissions are limited to the
   jobs that need them.
+- Annotated-tag GitHub Action pins now use the underlying commit SHA so
+  Scorecard result publication keeps working with `publish_results: true`.
+- Dependabot now tracks both npm dependencies and pinned GitHub Actions
+  updates.
+- Test coverage now includes property-based checks for CSRF parsing, endpoint
+  construction, and timeout environment parsing.
 
 ## [0.4.0] - 2026-04-02
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@vitest/coverage-v8": "^4.1.2",
         "eslint": "^10.1.0",
         "eslint-config-prettier": "^10.1.8",
+        "fast-check": "^4.6.0",
         "globals": "^17.4.0",
         "husky": "^9.1.7",
         "lint-staged": "^16.4.0",
@@ -2053,6 +2054,29 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/fast-check": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.6.0.tgz",
+      "integrity": "sha512-h7H6Dm0Fy+H4ciQYFxFjXnXkzR2kr9Fb22c0UBpHnm59K2zpr2t13aPTHlltFiNT6zuxp6HMPAVVvgur4BLdpA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3066,6 +3090,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@vitest/coverage-v8": "^4.1.2",
     "eslint": "^10.1.0",
     "eslint-config-prettier": "^10.1.8",
+    "fast-check": "^4.6.0",
     "globals": "^17.4.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",

--- a/test/scorecard-property.test.ts
+++ b/test/scorecard-property.test.ts
@@ -1,0 +1,141 @@
+import fc from "fast-check";
+import { describe, expect, it } from "vitest";
+
+import { extractPortalCsrfToken } from "../src/sdk/auth/csrf.js";
+import {
+  LibrusConfigurationError,
+  LibrusPortalPageError,
+} from "../src/sdk/models/errors.js";
+import { parseRequestTimeoutMsFromEnv } from "../src/sdk/requestTimeout.js";
+import { buildEndpoint } from "../src/sdk/synergia/request.js";
+
+const FAST_CHECK_SETTINGS = {
+  numRuns: 200,
+  seed: 20260404,
+} as const;
+
+const safeIdentifierArbitrary = fc.stringMatching(/^[A-Za-z0-9_-]{1,24}$/u);
+const safePathArbitrary = fc
+  .array(safeIdentifierArbitrary, { minLength: 1, maxLength: 4 })
+  .map((segments) => segments.join("/"));
+const queryValueArbitrary = fc.oneof(
+  fc.string(),
+  fc.integer(),
+  fc.boolean(),
+  fc.constant(null),
+  fc.constant(undefined),
+);
+
+describe("Scorecard-oriented property coverage", () => {
+  it("extracts CSRF tokens from nested malformed portal markup", () => {
+    fc.assert(
+      fc.property(safeIdentifierArbitrary, (token) => {
+        const html = `<main><section><form><div><input value="${token}" name="_token" type="hidden"></section>`;
+
+        expect(extractPortalCsrfToken(html)).toBe(token);
+      }),
+      FAST_CHECK_SETTINGS,
+    );
+  });
+
+  it("rejects generated portal markup when the _token input is missing", () => {
+    fc.assert(
+      fc.property(
+        safeIdentifierArbitrary.filter((name) => name !== "_token"),
+        safeIdentifierArbitrary,
+        (fieldName, fieldValue) => {
+          const html = `<form><div><input type="hidden" name="${fieldName}" value="${fieldValue}"><input type="hidden" name="_token_hint" value="${fieldValue}"></div></form>`;
+
+          expect(() => extractPortalCsrfToken(html)).toThrowError(
+            LibrusPortalPageError,
+          );
+        },
+      ),
+      FAST_CHECK_SETTINGS,
+    );
+  });
+
+  it("normalizes generated endpoint paths with arbitrary leading slashes", () => {
+    fc.assert(
+      fc.property(
+        safePathArbitrary,
+        fc.integer({ min: 0, max: 5 }),
+        (path, leadingSlashCount) => {
+          const endpoint = new URL(
+            buildEndpoint(
+              "https://api.librus.pl/3.0",
+              `${"/".repeat(leadingSlashCount)}${path}`,
+            ),
+          );
+
+          expect(endpoint.pathname).toBe(`/3.0/${path}`);
+        },
+      ),
+      FAST_CHECK_SETTINGS,
+    );
+  });
+
+  it("omits only nullish query values when building generated endpoints", () => {
+    fc.assert(
+      fc.property(
+        safePathArbitrary,
+        fc.record({
+          a: queryValueArbitrary,
+          b: queryValueArbitrary,
+          c: queryValueArbitrary,
+          d: queryValueArbitrary,
+        }),
+        (path, query) => {
+          const endpoint = new URL(
+            buildEndpoint("https://api.librus.pl/3.0", path, query),
+          );
+
+          for (const [key, value] of Object.entries(query)) {
+            if (value === null || value === undefined) {
+              expect(endpoint.searchParams.has(key)).toBe(false);
+            } else {
+              expect(endpoint.searchParams.get(key)).toBe(String(value));
+            }
+          }
+        },
+      ),
+      FAST_CHECK_SETTINGS,
+    );
+  });
+
+  it("accepts generated positive integer timeout strings", () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 1, max: Number.MAX_SAFE_INTEGER }), (n) => {
+        expect(parseRequestTimeoutMsFromEnv(String(n))).toBe(n);
+      }),
+      FAST_CHECK_SETTINGS,
+    );
+  });
+
+  it("rejects or parses arbitrary timeout strings consistently", () => {
+    fc.assert(
+      fc.property(fc.string(), (rawValue) => {
+        const trimmedValue = rawValue.trim();
+
+        if (!/^\d+$/u.test(trimmedValue)) {
+          expect(() => parseRequestTimeoutMsFromEnv(rawValue)).toThrowError(
+            LibrusConfigurationError,
+          );
+          return;
+        }
+
+        const parsedValue = Number.parseInt(trimmedValue, 10);
+
+        if (!Number.isSafeInteger(parsedValue) || parsedValue <= 0) {
+          expect(() => parseRequestTimeoutMsFromEnv(rawValue)).toThrowError(
+            LibrusConfigurationError,
+          );
+          return;
+        }
+
+        expect(parseRequestTimeoutMsFromEnv(rawValue)).toBe(parsedValue);
+      }),
+      FAST_CHECK_SETTINGS,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- add GitHub Actions Dependabot updates for pinned workflow SHAs
- add deterministic `fast-check` property coverage for CSRF parsing, endpoint building, and timeout env parsing
- fix annotated-tag action pins so Scorecard `publish_results` works again
- keep the changelog aligned with the repository security hardening work

## Why

The merged workflow-hardening PR improved the Scorecard configuration surface, but the live Scorecard workflow exposed one follow-up issue: `ossf/scorecard-action` had been pinned to an annotated tag object SHA instead of the underlying commit SHA accepted by Scorecard workflow verification. This PR fixes that, adds the planned GitHub Actions update maintenance, and adds detectable fuzz/property-test coverage for the main parsing helpers.

## Validation

- `npm run lint`
- `npm run build`
- `npm run test:coverage`
- `npm run pack:check`
- `npx prettier --check .github/workflows/ci.yml .github/workflows/codeql.yml .github/workflows/scorecard.yml .github/dependabot.yml CHANGELOG.md test/scorecard-property.test.ts package.json package-lock.json`

## Notes

- Repository rules for `master` were created directly on GitHub and classic branch protection was removed, so Scorecard can read branch policy without the previous token-visibility error.
- The manual Scorecard run on `master` after PR #45 reached a computed score of `7.0`, but publication failed because of the annotated-tag pin for `ossf/scorecard-action`. This PR fixes that publication issue.
- Full local `npm run validate` in this checkout is still affected by the unrelated untracked `.tasks/README.md` formatting issue in the working tree, so the validation here used the repo’s individual gates instead.
