### PR TITLE
[codex] Update Scorecard artifact upload runtime

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Upload Scorecard artifact
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: scorecard-results
           path: scorecard-results.sarif

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   Scorecard result publication keeps working with `publish_results: true`.
 - Dependabot now tracks both npm dependencies and pinned GitHub Actions
   updates.
+- Scorecard artifact uploads now use `actions/upload-artifact@v7.0.0` so the
+  workflow no longer relies on a Node.js 20 action runtime on github.com.
 - Test coverage now includes property-based checks for CSRF parsing, endpoint
   construction, and timeout environment parsing.
 


### PR DESCRIPTION
## Summary

- upgrade the Scorecard artifact upload step to `actions/upload-artifact@v7.0.0`
- remove the deprecated Node.js 20 action runtime from the Scorecard workflow on github.com
- note the workflow runtime update in the changelog

## Why

The latest successful Scorecard run still emitted a GitHub Actions deprecation annotation because the workflow was using `actions/upload-artifact@v4`, which currently runs on Node.js 20. GitHub has announced the Node 20 hosted runner deprecation, so this PR moves the workflow to the current Node 24-capable artifact upload action.

## Validation

- `npx prettier --check .github/workflows/scorecard.yml CHANGELOG.md`

## Verification

- merged into `master` as `eb5d4de85b3005992acd2105fbdea5526a2d7f6d`
- reran the `Scorecard` workflow on `master`: [run 23980747670](https://github.com/andrewkoltsov/librus-sdk/actions/runs/23980747670)
- the previous GitHub warning about a Node.js 20 `actions/upload-artifact` runtime no longer appears in that run
- public Scorecard remained `7.5` for the rerun commit

## Follow-up

A separate warning still appears during `github/codeql-action/upload-sarif`: Node's `DEP0169` `url.parse()` deprecation. That warning is outside the `actions/upload-artifact` runtime issue addressed by this PR.

## Source

- official release: `actions/upload-artifact` `v7.0.0`