### PR TITLE
[codex] Raise Node baseline to 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install dependencies
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- Minimum supported Node.js is now 22.x, CI and CodeQL validation now run on
+  Node 22, and development type definitions now track the Node 22 line.
 - GitHub Actions workflows now pin third-party and GitHub-hosted actions by
   commit hash, and write-scoped workflow token permissions are limited to the
   jobs that need them.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ supply-chain signals over time.
 
 ## Install
 
+This package requires Node.js 22 or newer.
+
 Install the package from npm:
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "@types/node": "^20.19.37",
+        "@types/node": "^22.19.17",
         "@vitest/coverage-v8": "^4.1.2",
         "eslint": "^10.1.0",
         "eslint-config-prettier": "^10.1.8",
@@ -36,7 +36,7 @@
         "vitest": "^4.1.2"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -1130,9 +1130,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
-      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "./openapi.json": "./openapi.json"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
@@ -72,7 +72,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@types/node": "^20.19.37",
+    "@types/node": "^22.19.17",
     "@vitest/coverage-v8": "^4.1.2",
     "eslint": "^10.1.0",
     "eslint-config-prettier": "^10.1.8",


### PR DESCRIPTION
## Summary
- raise the published minimum Node.js version from 20 to 22
- align `@types/node` with the Node 22 line and refresh the lockfile
- run CI and CodeQL setup on Node 22 and document the runtime requirement in the README/changelog

## Why
Node 20 reaches end-of-life on April 30, 2026. Keeping the package baseline on 20 weakens the support contract while newer maintained LTS lines are available.

## Impact
Consumers now need Node.js 22 or newer to use the SDK and CLI.

## Validation
- `npx -y node@22 --version`
- `npx -y node@22 ./node_modules/eslint/bin/eslint.js .`
- `npx -y node@22 ./node_modules/prettier/bin/prettier.cjs --check README.md CHANGELOG.md package.json package-lock.json .github/workflows/ci.yml .github/workflows/codeql.yml`
- `npx -y node@22 ./node_modules/typescript/bin/tsc -p tsconfig.json`
- `npx -y node@22 ./node_modules/vitest/vitest.mjs run --coverage`
- `npx -y node@22 ./scripts/pack-check.mjs`

Note: local `npm run validate` is currently affected by an untracked `.tasks/README.md` in the working tree, so the formatting check was run against the tracked files in this change set. The PR CI run should execute the full validation gate on a clean checkout.
