### PR TITLE
[codex] Release 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-04-04
+
 ### Added
 
 - README now exposes the public OpenSSF Scorecard badge and report link for the

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.3",
   "info": {
     "title": "Librus Synergia API (SDK-supported subset)",
-    "version": "0.4.0",
+    "version": "0.4.1",
     "description": "Best-effort OpenAPI document generated from the SDK's supported child-scoped Synergia GET surface. Authentication starts on portal.librus.pl; this document covers the subsequent bearer-token calls against api.librus.pl/3.0."
   },
   "servers": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "librus-sdk",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "librus-sdk",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@valibot/to-json-schema": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librus-sdk",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "TypeScript SDK and CLI for the Librus family portal flow.",
   "author": "Andrey Koltsov",
   "repository": {


### PR DESCRIPTION
## Summary
- bump the package version from `0.4.0` to `0.4.1`
- move the current `Unreleased` notes into a dated `0.4.1` changelog section
- prepare `master` for the annotated `v0.4.1` tag that triggers publishing

## Why
The Node 22 baseline change and the related repository updates are now merged to `master`, so the release metadata needs to be cut before tagging.

## Validation
- `node ./scripts/extract-release-notes.mjs 0.4.1`
- `node ./scripts/pack-check.mjs`
- `npx -y node@22 ./node_modules/prettier/bin/prettier.cjs --check CHANGELOG.md package.json package-lock.json`
