### PR TITLE
[codex] Prepare 0.4.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-04-13
+
+### Fixed
+
+- Development and CI dependency refresh now removes the disclosed high-severity
+  Vite advisories `GHSA-4w7w-66w2-5vf9`, `GHSA-v2wj-q39q-566r`, and
+  `GHSA-p9ff-h696-f583` from maintainer workflows and repository validation
+  gates; the published SDK and CLI runtime surface is otherwise unchanged.
+
 ## [0.4.1] - 2026-04-04
 
 ### Added

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.3",
   "info": {
     "title": "Librus Synergia API (SDK-supported subset)",
-    "version": "0.4.1",
+    "version": "0.4.2",
     "description": "Best-effort OpenAPI document generated from the SDK's supported child-scoped Synergia GET surface. Authentication starts on portal.librus.pl; this document covers the subsequent bearer-token calls against api.librus.pl/3.0."
   },
   "servers": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "librus-sdk",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "librus-sdk",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
         "@valibot/to-json-schema": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librus-sdk",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "TypeScript SDK and CLI for the Librus family portal flow.",
   "author": "Andrey Koltsov",
   "repository": {


### PR DESCRIPTION
## What changed
- bump the package version from `0.4.1` to `0.4.2`
- add changelog-backed release notes for the security maintenance patch
- regenerate `openapi.json` so the checked-in document version matches the release version

## Why
- `master` now includes the dependency updates that removed the disclosed high-severity Vite advisories from maintainer and CI workflows
- the release workflow requires a matching `package.json` version, changelog section, and checked-in OpenAPI document before tagging `v0.4.2`

## Impact
- no SDK or CLI runtime behavior changes
- prepares the repository for an annotated `v0.4.2` tag and npm/GitHub release publication

## Validation
- `node ./scripts/extract-release-notes.mjs 0.4.2`
- `npm_config_cache=/tmp/librus-sdk-release-cache npm run validate`