### PR TITLE
[codex] Fix code scanning body decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- CLI text rendering now decodes escaped message-body sequences without
+  dropping mixed raw backslashes, closing the outstanding CodeQL sanitization
+  finding in the terminal formatter.
+
 ## [0.4.2] - 2026-04-13
 
 ### Fixed

--- a/src/cli/output/render.ts
+++ b/src/cli/output/render.ts
@@ -416,19 +416,65 @@ function formatBodyScalar(
 }
 
 function hasJsonEscapes(value: string): boolean {
-  return /\\u[0-9a-fA-F]{4}|\\["\\/bfnrt]/.test(value);
+  return /\\u[0-9a-fA-F]{4}|\\["\\/nt]/.test(value);
 }
 
 function decodeJsonEscapedString(value: string): string {
-  const escaped = value
-    .replace(/"/g, '\\"')
-    .replace(/\r/g, "\\r")
-    .replace(/\n/g, "\\n")
-    .replace(/\t/g, "\\t");
+  let decoded = "";
 
-  try {
-    return JSON.parse(`"${escaped}"`) as string;
-  } catch {
-    return value;
+  for (let index = 0; index < value.length; index += 1) {
+    const current = value[index];
+
+    if (current !== "\\") {
+      decoded += current;
+      continue;
+    }
+
+    const next = value[index + 1];
+
+    if (
+      next === "u" &&
+      /^[0-9a-fA-F]{4}$/.test(value.slice(index + 2, index + 6))
+    ) {
+      decoded += String.fromCodePoint(
+        Number.parseInt(value.slice(index + 2, index + 6), 16),
+      );
+      index += 5;
+      continue;
+    }
+
+    if (next === '"') {
+      decoded += '"';
+      index += 1;
+      continue;
+    }
+
+    if (next === "\\") {
+      decoded += "\\";
+      index += 1;
+      continue;
+    }
+
+    if (next === "/") {
+      decoded += "/";
+      index += 1;
+      continue;
+    }
+
+    if (next === "n") {
+      decoded += "\n";
+      index += 1;
+      continue;
+    }
+
+    if (next === "t") {
+      decoded += "\t";
+      index += 1;
+      continue;
+    }
+
+    decoded += current;
   }
+
+  return decoded;
 }

--- a/test/render.test.ts
+++ b/test/render.test.ts
@@ -152,6 +152,45 @@ describe("renderTextSections", () => {
     expect(output).not.toContain("<br>");
   });
 
+  it("decodes JSON escapes without corrupting raw backslashes in the same body", () => {
+    const output = renderTextSections(
+      [
+        {
+          title: "Message",
+          value: {
+            Body: String.raw`Windows path C:\Temp\reports\nSecond line`,
+          },
+        },
+      ],
+      { width: 120 },
+    );
+
+    expect(output).toContain(String.raw`Windows path C:\Temp\reports`);
+    expect(output).toContain("Second line");
+    expect(output).not.toContain(String.raw`\nSecond line`);
+  });
+
+  it("decodes escaped unicode, whitespace, and quotes in message bodies", () => {
+    const output = renderTextSections(
+      [
+        {
+          title: "Message",
+          value: {
+            Body: String.raw`Unicode: \u0144\nTabbed:\t\"Quoted\"`,
+          },
+        },
+      ],
+      { width: 120 },
+    );
+
+    expect(output).toContain("Unicode: ń");
+    expect(output).toContain("Tabbed:");
+    expect(output).toContain('"Quoted"');
+    expect(output).not.toContain(String.raw`\u0144`);
+    expect(output).not.toContain(String.raw`\t`);
+    expect(output).not.toContain(String.raw`\"Quoted\"`);
+  });
+
   it("keeps plain body text inline and preserves invalid date-like values", () => {
     const output = renderTextSections(
       [


### PR DESCRIPTION
## Summary
- replace the CLI message-body JSON escape decoding hack with explicit escape handling for the sequences the renderer actually needs
- add regression coverage for mixed raw backslashes plus `\u`, `\n`, `\t`, and `\"` message body content
- document the CodeQL-oriented renderer fix in the changelog

## Why
The previous implementation built a JSON string and fed it through `JSON.parse`, which triggered the open CodeQL sanitization finding and behaved ambiguously around mixed escaped content and raw backslashes.

## Impact
- public SDK and CLI interfaces stay unchanged
- CLI text output for message bodies becomes safer and more predictable
- advisory Scorecard alerts were triaged separately in the repository settings; this PR is only the code and test fix for the remaining actionable CodeQL finding

## Validation
- `npm run lint`
- `npm run build`
- `npm run test:coverage`
- `npm run pack:check`
- targeted `npx prettier --check src/cli/output/render.ts test/render.test.ts CHANGELOG.md`

## Notes
`npm run validate` in the current worktree still reports a pre-existing formatting issue in untracked `.tasks/README.md`, so validation was run as the equivalent scoped checks above without touching that unrelated path.