### PR TITLE
[codex] Prepare 0.4.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.4.3] - 2026-04-13
+
 ### Fixed
 
 - CLI text rendering now decodes escaped message-body sequences without

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.3",
   "info": {
     "title": "Librus Synergia API (SDK-supported subset)",
-    "version": "0.4.2",
+    "version": "0.4.3",
     "description": "Best-effort OpenAPI document generated from the SDK's supported child-scoped Synergia GET surface. Authentication starts on portal.librus.pl; this document covers the subsequent bearer-token calls against api.librus.pl/3.0."
   },
   "servers": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "librus-sdk",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "librus-sdk",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "MIT",
       "dependencies": {
         "@valibot/to-json-schema": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librus-sdk",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "TypeScript SDK and CLI for the Librus family portal flow.",
   "author": "Andrey Koltsov",
   "repository": {


### PR DESCRIPTION
## Summary
- bump `librus-sdk` version to `0.4.3`
- move the current unreleased security fix note into the `0.4.3` changelog section
- keep the checked-in OpenAPI document version aligned with the release version

## Why
The CodeQL body-decoding fix from #60 has landed on `master` and is patch-release material. The release workflow requires `package.json`, `CHANGELOG.md`, and the checked-in OpenAPI document to agree on the release version before tagging.

## Validation
- `npm run lint`
- `npm run build`
- `npm run test:coverage`
- `npm run pack:check`
- `npm run openapi:check`
- `npx prettier --check package.json package-lock.json CHANGELOG.md openapi.json`

## Notes
Local `npm run validate` remains blocked by an unrelated untracked `.tasks/README.md` formatting issue in this worktree, so the equivalent release checks were run directly.