### PR TITLE
[codex] Automate OpenAPI version sync

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -65,7 +65,8 @@ continues to publish to npmjs only.
 
 ## Release Checklist
 
-1. Update `package.json` to the release version.
+1. Run `npm version X.Y.Z --no-git-tag-version` to update
+   `package.json`, `package-lock.json`, and `openapi.json` together.
 2. Move the release notes from `Unreleased` into a new versioned section in
    `CHANGELOG.md`.
 3. Merge the release commit to `master`.
@@ -75,6 +76,9 @@ continues to publish to npmjs only.
 7. Verify that the release workflow publishes the package and creates the
    GitHub Release.
 8. Confirm the workflow's published-package verification step succeeds.
+
+Using `npm version` matters here because the repository's `version` lifecycle
+hook regenerates `openapi.json` from the new package version automatically.
 
 ## Maintainer Continuity
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "lint:fix": "eslint . --fix",
     "openapi:check": "tsx ./scripts/generate-openapi.ts --check",
     "openapi:generate": "tsx ./scripts/generate-openapi.ts",
+    "version": "npm run openapi:generate",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "pack:check": "node ./scripts/pack-check.mjs",


### PR DESCRIPTION
## Summary
- run `npm run openapi:generate` automatically from the `npm version` lifecycle
- document the release flow so `npm version X.Y.Z --no-git-tag-version` becomes the standard version-bump step

## Why
Release prep has now hit the same failure twice: `package.json` was bumped, but `openapi.json` still carried the old version and `test:coverage` caught it later. The version bump should keep those files in sync automatically instead of relying on memory.

## Validation
- temporarily ran `npm version 0.4.4 --no-git-tag-version` and confirmed `openapi.json` moved to `0.4.4`
- restored the worktree back to `0.4.3` with `npm version 0.4.3 --no-git-tag-version`
- `npm run openapi:check`
- `npm run lint`
- `npx prettier --check package.json docs/releasing.md`

## Notes
Only maintainer workflow files changed. The unrelated untracked `.tasks/` directory was left untouched.