### PR TITLE
[codex] Improve env credential errors

### DIFF
--- a/.tasks/rearchitect/implementation-checklist.md
+++ b/.tasks/rearchitect/implementation-checklist.md
@@ -1,0 +1,93 @@
+# Rearchitect Implementation Checklist
+
+Current branch snapshot: `codex/dependabot-saturday`.
+
+Use this file as the tracking view for `.tasks/rearchitect`. A checked box means the task is implemented in the current worktree. An unchecked box means it is planned, deferred, or not started.
+
+## Recommended Order
+
+- [x] [06 - Clearer env var error messages](06-env-validation.md) - implemented
+- [ ] [08 - Narrow error-path test gaps](08-test-coverage.md) - not implemented
+- [ ] [12 - README: three missing worked examples](12-readme-patterns.md) - not implemented
+- [ ] [02 - Token refresh at the session layer](02-session-refresh.md) - not implemented
+- [ ] [04 - Retry/backoff for transient failures](04-retry-backoff.md) - not implemented
+- [ ] [03 - Split monolithic `openapi.ts`](03-openapi-split.md) - not implemented
+- [ ] [01 - Split `SynergiaApiClient` by domain](01-domain-split.md) - not implemented
+- [ ] [05 - Logging hooks](05-logging-hooks.md) - not implemented
+- [ ] [11 - Fixture-backed contract tests](11-contract-tests.md) - not implemented
+- [ ] [09 - CLI boilerplate](09-cli-boilerplate.md) - deferred; no implementation planned until a concrete trigger appears
+
+## First Batch
+
+These are the safest tasks to land first because they are small and mostly additive.
+
+- [x] [06 - Clearer env var error messages](06-env-validation.md)
+  - Current state: `LibrusSession.fromEnv()` reports missing or empty primary and fallback credential env vars without exposing values.
+  - Expected change: mention primary and fallback env vars without exposing values.
+  - Main files: `../../src/sdk/LibrusSession.ts`, `../../test/librus-session.test.ts`, `../../README.md`
+
+- [ ] [08 - Narrow error-path test gaps](08-test-coverage.md)
+  - Current state: no dedicated tests for `combineAbortSignals` or response-validation issue truncation.
+  - Correction to task note: current validation code truncates to 3 issues but does not add a "remaining issues" marker, so that part requires a small production behavior decision.
+  - Main files: `../../src/sdk/requestTimeout.ts`, `../../src/sdk/validation/responseValidation.ts`, `../../test/`
+
+- [ ] [12 - README: three missing worked examples](12-readme-patterns.md)
+  - Current state: README documents constructors and env vars, but does not include the planned worked examples.
+  - Expected change now: add custom fetch and child-selection examples.
+  - Hold until later: retry example should wait for [04](04-retry-backoff.md).
+  - Main file: `../../README.md`
+
+## Reliability Batch
+
+These solve real SDK behavior gaps and should land with focused tests.
+
+- [ ] [02 - Token refresh at the session layer](02-session-refresh.md)
+  - Current state: `forChild()` creates `SynergiaApiClient` with a fixed bearer token; 401 responses are thrown directly.
+  - Important implementation note: refresh must bypass or invalidate the cached Synergia accounts response, otherwise it may return the same stale token.
+  - Main files: `../../src/sdk/LibrusSession.ts`, `../../src/sdk/synergia/SynergiaApiClient.ts`, `../../src/sdk/synergia/request.ts`, `../../test/librus-session.test.ts`
+
+- [ ] [04 - Retry/backoff for transient failures](04-retry-backoff.md)
+  - Current state: Synergia requests fail immediately on 429/5xx.
+  - Important implementation note: define whether timeout applies per attempt or across the full retry operation before coding.
+  - Main files: `../../src/sdk/synergia/request.ts`, `../../src/sdk/synergia/SynergiaApiClient.ts`, `../../test/`
+
+## Structural Batch
+
+These are worthwhile only when the repo is actively expanding endpoint coverage or OpenAPI edits become a merge-conflict problem.
+
+- [ ] [03 - Split monolithic `openapi.ts`](03-openapi-split.md)
+  - Current state: `src/sdk/openapi.ts` is still a single large file.
+  - Gate: add or preserve a golden `openapi.json` check before moving code.
+  - Main files: `../../src/sdk/openapi.ts`, `../../src/sdk/openapi/`, `../../test/openapi.test.ts`
+
+- [ ] [01 - Split `SynergiaApiClient` by domain](01-domain-split.md)
+  - Current state: `SynergiaApiClient.ts` is still a single class/file containing request wiring and domain methods.
+  - Gate: preserve constructor, method names, parameter arity, and return types.
+  - Main files: `../../src/sdk/synergia/SynergiaApiClient.ts`, `../../src/sdk/synergia/domains/`, `../../test/`
+
+## Later / Optional
+
+- [ ] [05 - Logging hooks](05-logging-hooks.md)
+  - Current state: no SDK logger interface.
+  - Recommendation: keep deferred until refresh/retry exists or a CLI verbose mode needs it.
+  - Main files: `../../src/sdk/`, `../../src/cli/main.ts`, `../../README.md`
+
+- [ ] [11 - Fixture-backed contract tests](11-contract-tests.md)
+  - Current state: live integration tests exist, but no record/replay fixture layer.
+  - Recommendation: start with a small replay pilot and strict redaction tests before wiring broad CI coverage.
+  - Main files: `../../test/integration/`, `../../package.json`, `../../README.md`, `../../.github/workflows/`
+
+- [ ] [09 - CLI boilerplate](09-cli-boilerplate.md)
+  - Current state: deferred by design.
+  - Trigger only if command boilerplate demonstrably starts causing drift.
+
+## Already Solid
+
+These are not tasks to implement; they are current properties to preserve while changing the code.
+
+- [x] Portal-based authentication flow is the supported path.
+- [x] `SynergiaApiClient` exposes named child-scoped methods rather than a generic public query builder.
+- [x] OpenAPI generation is already checked against checked-in `openapi.json`.
+- [x] Request timeout parsing and validation already exist.
+- [x] CLI output is already centralized through command helpers.
+- [x] Live integration tests are already opt-in and credential-gated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Missing `LibrusSession.fromEnv()` credential errors now name the primary and
+  fallback environment variables and distinguish unset values from empty ones.
+
 ## [0.4.3] - 2026-04-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -61,17 +61,21 @@ CLI published from this repository.
 `LibrusSession.fromEnv()` and the CLI read credentials and timeout settings from
 these variables:
 
-| Variable                 | Required | Purpose                                            |
-| ------------------------ | -------- | -------------------------------------------------- |
-| `LIBRUS_PORTAL_EMAIL`    | Yes      | Portal login email used for `portal.librus.pl`.    |
-| `LIBRUS_PORTAL_PASSWORD` | Yes      | Portal login password used for `portal.librus.pl`. |
-| `LIBRUS_EMAIL`           | Fallback | Compatibility alias for `LIBRUS_PORTAL_EMAIL`.     |
-| `LIBRUS_PASSWORD`        | Fallback | Compatibility alias for `LIBRUS_PORTAL_PASSWORD`.  |
-| `LIBRUS_TIMEOUT_MS`      | No       | Positive integer request timeout in milliseconds.  |
+| Variable                 | Required | Purpose                                                     |
+| ------------------------ | -------- | ----------------------------------------------------------- |
+| `LIBRUS_PORTAL_EMAIL`    | Yes      | Portal login email used for `portal.librus.pl`.             |
+| `LIBRUS_PORTAL_PASSWORD` | Yes      | Portal login password used for `portal.librus.pl`.          |
+| `LIBRUS_EMAIL`           | Fallback | Compatibility alias when `LIBRUS_PORTAL_EMAIL` is unset.    |
+| `LIBRUS_PASSWORD`        | Fallback | Compatibility alias when `LIBRUS_PORTAL_PASSWORD` is unset. |
+| `LIBRUS_TIMEOUT_MS`      | No       | Positive integer request timeout in milliseconds.           |
 
 If no timeout is configured, portal and child-scoped SDK requests default to
 `30000` milliseconds. Invalid timeout values fail fast with
 `CONFIGURATION_ERROR`.
+
+Empty credential variables are treated as invalid. If a portal-prefixed
+credential variable is set but empty, the compatibility alias for that
+credential is ignored.
 
 ### Top-Level SDK Entry Points
 
@@ -267,7 +271,7 @@ JSON stderr shape is stable:
 {
   "error": {
     "code": "CONFIGURATION_ERROR",
-    "message": "Missing portal credentials.",
+    "message": "Missing portal credentials. Email: LIBRUS_PORTAL_EMAIL is unset; fallback LIBRUS_EMAIL is unset. Password: LIBRUS_PORTAL_PASSWORD is unset; fallback LIBRUS_PASSWORD is unset.",
     "details": {}
   }
 }

--- a/src/sdk/LibrusSession.ts
+++ b/src/sdk/LibrusSession.ts
@@ -19,6 +19,30 @@ import {
   validateOptionalRequestTimeoutMs,
 } from "./requestTimeout.js";
 
+type PortalCredentialEnvName =
+  | "LIBRUS_EMAIL"
+  | "LIBRUS_PASSWORD"
+  | "LIBRUS_PORTAL_EMAIL"
+  | "LIBRUS_PORTAL_PASSWORD";
+
+interface PortalCredentialEnvField {
+  label: string;
+  primary: PortalCredentialEnvName;
+  fallback: PortalCredentialEnvName;
+}
+
+const PORTAL_EMAIL_ENV: PortalCredentialEnvField = {
+  label: "Email",
+  primary: "LIBRUS_PORTAL_EMAIL",
+  fallback: "LIBRUS_EMAIL",
+};
+
+const PORTAL_PASSWORD_ENV: PortalCredentialEnvField = {
+  label: "Password",
+  primary: "LIBRUS_PORTAL_PASSWORD",
+  fallback: "LIBRUS_PASSWORD",
+};
+
 export interface LibrusSessionOptions {
   credentials: PortalCredentials;
   portalClient?: PortalClient;
@@ -65,12 +89,12 @@ export class LibrusSession {
   }
 
   static fromEnv(env: NodeJS.ProcessEnv = process.env): LibrusSession {
-    const email = env.LIBRUS_PORTAL_EMAIL ?? env.LIBRUS_EMAIL;
-    const password = env.LIBRUS_PORTAL_PASSWORD ?? env.LIBRUS_PASSWORD;
+    const email = resolvePortalCredentialEnv(env, PORTAL_EMAIL_ENV);
+    const password = resolvePortalCredentialEnv(env, PORTAL_PASSWORD_ENV);
 
     if (!email || !password) {
       throw new LibrusConfigurationError(
-        "Missing portal credentials. Set LIBRUS_PORTAL_EMAIL and LIBRUS_PORTAL_PASSWORD.",
+        buildMissingPortalCredentialsMessage(env),
       );
     }
 
@@ -160,4 +184,50 @@ export class LibrusSession {
         : selectorOrChild;
     return new SynergiaApiClient(child.accessToken, this.synergiaClientOptions);
   }
+}
+
+function resolvePortalCredentialEnv(
+  env: NodeJS.ProcessEnv,
+  field: PortalCredentialEnvField,
+): string | undefined {
+  return env[field.primary] ?? env[field.fallback];
+}
+
+function buildMissingPortalCredentialsMessage(env: NodeJS.ProcessEnv): string {
+  return [
+    "Missing portal credentials.",
+    describeCredentialEnvIssue(env, PORTAL_EMAIL_ENV),
+    describeCredentialEnvIssue(env, PORTAL_PASSWORD_ENV),
+  ]
+    .filter((part): part is string => part !== undefined)
+    .join(" ");
+}
+
+function describeCredentialEnvIssue(
+  env: NodeJS.ProcessEnv,
+  field: PortalCredentialEnvField,
+): string | undefined {
+  const resolvedValue = resolvePortalCredentialEnv(env, field);
+
+  if (resolvedValue) {
+    return undefined;
+  }
+
+  const primaryValue = env[field.primary];
+
+  if (primaryValue !== undefined) {
+    return `${field.label}: ${field.primary} is ${describeEnvValueState(
+      primaryValue,
+    )}; fallback ${field.fallback} is ignored because ${field.primary} is set.`;
+  }
+
+  const fallbackValue = env[field.fallback];
+
+  return `${field.label}: ${field.primary} is unset; fallback ${
+    field.fallback
+  } is ${describeEnvValueState(fallbackValue)}.`;
+}
+
+function describeEnvValueState(value: string | undefined): "empty" | "unset" {
+  return value === undefined ? "unset" : "empty";
 }

--- a/test/librus-session.test.ts
+++ b/test/librus-session.test.ts
@@ -86,6 +86,19 @@ function readSynergiaClientRequestTimeoutMs(client: unknown): number {
   ).requestTimeoutMs;
 }
 
+function captureConfigurationError(
+  callback: () => unknown,
+): LibrusConfigurationError {
+  try {
+    callback();
+  } catch (error) {
+    expect(error).toBeInstanceOf(LibrusConfigurationError);
+    return error as LibrusConfigurationError;
+  }
+
+  throw new Error("Expected LibrusConfigurationError to be thrown.");
+}
+
 function withTemporaryPortalEnv<T>(
   env: Partial<
     Record<
@@ -187,19 +200,67 @@ describe("LibrusSession.fromEnv", () => {
   });
 
   it("fails when the email is missing", () => {
-    expect(() =>
+    const error = captureConfigurationError(() =>
       LibrusSession.fromEnv({
         LIBRUS_PORTAL_PASSWORD: "portal-secret",
       }),
-    ).toThrowError(LibrusConfigurationError);
+    );
+
+    expect(error).toMatchObject({
+      code: "CONFIGURATION_ERROR",
+      message:
+        "Missing portal credentials. Email: LIBRUS_PORTAL_EMAIL is unset; fallback LIBRUS_EMAIL is unset.",
+    });
   });
 
   it("fails when the password is missing", () => {
-    expect(() =>
+    const error = captureConfigurationError(() =>
       LibrusSession.fromEnv({
         LIBRUS_PORTAL_EMAIL: "portal@example.com",
       }),
-    ).toThrowError(LibrusConfigurationError);
+    );
+
+    expect(error).toMatchObject({
+      code: "CONFIGURATION_ERROR",
+      message:
+        "Missing portal credentials. Password: LIBRUS_PORTAL_PASSWORD is unset; fallback LIBRUS_PASSWORD is unset.",
+    });
+  });
+
+  it("reports all credential env names when all credentials are unset", () => {
+    const error = captureConfigurationError(() => LibrusSession.fromEnv({}));
+
+    expect(error.message).toBe(
+      "Missing portal credentials. Email: LIBRUS_PORTAL_EMAIL is unset; fallback LIBRUS_EMAIL is unset. Password: LIBRUS_PORTAL_PASSWORD is unset; fallback LIBRUS_PASSWORD is unset.",
+    );
+  });
+
+  it("reports empty primary credential env vars without falling back", () => {
+    const error = captureConfigurationError(() =>
+      LibrusSession.fromEnv({
+        LIBRUS_EMAIL: "compat@example.com",
+        LIBRUS_PASSWORD: "compat-secret",
+        LIBRUS_PORTAL_EMAIL: "",
+        LIBRUS_PORTAL_PASSWORD: "",
+      }),
+    );
+
+    expect(error.message).toBe(
+      "Missing portal credentials. Email: LIBRUS_PORTAL_EMAIL is empty; fallback LIBRUS_EMAIL is ignored because LIBRUS_PORTAL_EMAIL is set. Password: LIBRUS_PORTAL_PASSWORD is empty; fallback LIBRUS_PASSWORD is ignored because LIBRUS_PORTAL_PASSWORD is set.",
+    );
+  });
+
+  it("does not include credential values in missing credential errors", () => {
+    const error = captureConfigurationError(() =>
+      LibrusSession.fromEnv({
+        LIBRUS_EMAIL: "compat.secret@example.com",
+        LIBRUS_PASSWORD: "compat-password-secret",
+        LIBRUS_PORTAL_EMAIL: "",
+      }),
+    );
+
+    expect(error.message).not.toContain("compat.secret@example.com");
+    expect(error.message).not.toContain("compat-password-secret");
   });
 
   it("fails when LIBRUS_TIMEOUT_MS is invalid", () => {


### PR DESCRIPTION
## Summary

- Improve LibrusSession.fromEnv() missing-credential diagnostics to name primary and fallback env vars.
- Distinguish unset and empty credential variables without exposing values.
- Document the env resolution contract and mark rearchitect task 06 complete.

## Validation

- npm test
- npm run build
- npx prettier --check src/sdk/LibrusSession.ts test/librus-session.test.ts README.md CHANGELOG.md .tasks/rearchitect/implementation-checklist.md