### PR TITLE
[codex] add Snyk security badge

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,0 +1,44 @@
+name: Snyk Security
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  schedule:
+    - cron: "15 7 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Dependency vulnerability scan
+    runs-on: ubuntu-latest
+    env:
+      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Fail when SNYK_TOKEN is unavailable
+        if: env.SNYK_TOKEN == ''
+        run: |
+          echo "SNYK_TOKEN GitHub Actions secret is required for Snyk Security."
+          exit 1
+
+      - name: Run Snyk dependency scan
+        uses: snyk/actions/node@9adf32b1121593767fc3c057af55b55db032dc04 # v1.0.0
+        with:
+          args: --severity-threshold=high

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- README now exposes CI, CodeQL, and Snyk Security status badges alongside the
+  public OpenSSF Scorecard badge.
+- Snyk Security now runs in GitHub Actions and fails on high or critical
+  dependency vulnerabilities.
+
+### Changed
+
+- Vitest branch coverage enforcement now requires at least 84%.
+
 ### Fixed
 
 - Missing `LibrusSession.fromEnv()` credential errors now name the primary and

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # librus-sdk
 
+[![CI](https://github.com/andrewkoltsov/librus-sdk/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/andrewkoltsov/librus-sdk/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/andrewkoltsov/librus-sdk/actions/workflows/codeql.yml/badge.svg?branch=master)](https://github.com/andrewkoltsov/librus-sdk/actions/workflows/codeql.yml)
+[![Snyk Security](https://github.com/andrewkoltsov/librus-sdk/actions/workflows/snyk.yml/badge.svg?branch=master)](https://github.com/andrewkoltsov/librus-sdk/actions/workflows/snyk.yml)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/andrewkoltsov/librus-sdk/badge)](https://scorecard.dev/viewer/?uri=github.com/andrewkoltsov/librus-sdk)
 
 Fresh TypeScript SDK and CLI for the Librus family portal flow.
@@ -419,6 +422,8 @@ Current CI jobs:
 
 - `Validation gate`: runs the required `npm run validate` path before merge.
 - `Dependency vulnerability gate`: fails on high or critical npm advisories.
+- `Snyk Security`: fails on high or critical dependency vulnerabilities using
+  the configured `SNYK_TOKEN` GitHub Actions secret.
 - `Trivy scan (informational)`: publishes vulnerability and secret-scan results
   for review.
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     coverage: {
       provider: "v8",
       thresholds: {
-        branches: 80,
+        branches: 84,
       },
     },
     include: ["test/**/*.test.ts"],


### PR DESCRIPTION
## Summary

- Add CI, CodeQL, and Snyk Security badges to the README while keeping the numeric OpenSSF Scorecard badge.
- Add a Snyk Security GitHub Actions workflow that uses `SNYK_TOKEN` and fails on high or critical dependency vulnerabilities.
- Raise the enforced Vitest branch coverage threshold from 80% to 84%.

## Validation

- `npm run test:coverage`
- `npx prettier --check vitest.config.ts README.md CHANGELOG.md .github/workflows/snyk.yml`
- `git diff --check`
- `npm run build`
- `npm run pack:check`

Note: full `npm run validate` is currently blocked locally by pre-existing untracked `.tasks/*` files that fail repository-wide Prettier checks.