### PR TITLE
[codex] Prepare 0.4.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.4.4] - 2026-05-03
+
 ### Added
 
 - README now exposes CI, CodeQL, and Snyk Security status badges alongside the

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.3",
   "info": {
     "title": "Librus Synergia API (SDK-supported subset)",
-    "version": "0.4.3",
+    "version": "0.4.4",
     "description": "Best-effort OpenAPI document generated from the SDK's supported child-scoped Synergia GET surface. Authentication starts on portal.librus.pl; this document covers the subsequent bearer-token calls against api.librus.pl/3.0."
   },
   "servers": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "librus-sdk",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "librus-sdk",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "license": "MIT",
       "dependencies": {
         "@valibot/to-json-schema": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librus-sdk",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "TypeScript SDK and CLI for the Librus family portal flow.",
   "author": "Andrey Koltsov",
   "repository": {


### PR DESCRIPTION
## Summary

Prepare the patch release for `librus-sdk@0.4.4`.

## Changes

- Bump `package.json` and `package-lock.json` to `0.4.4`.
- Regenerate `openapi.json` so the generated API document reports `0.4.4`.
- Move the accumulated changelog notes from `Unreleased` into `0.4.4` dated `2026-05-03`.

## Validation

- `npm run lint`
- `npx prettier --check CHANGELOG.md package.json package-lock.json openapi.json`
- `npm run build`
- `npm run test:coverage`
- `npm run pack:check`

Note: full local `npm run validate` also runs `prettier --check .`, which currently sees unrelated untracked `.tasks/**` files in this checkout. Those files are not part of this PR.
