### PR TITLE
Align agent guidance with Node 22 support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,8 @@ npm run cli -- grades list --child <id-or-login>
   - `PortalClient` handles portal login/session concerns.
   - `LibrusSession` orchestrates login, child discovery, and child selection.
   - `SynergiaApiClient` handles authenticated API calls for a specific child account.
-- Keep compatibility with Node 20+.
+- Keep compatibility with Node 22+. Node 22 is the supported runtime floor for
+  SDK, CLI, CI, and dependency updates.
 
 ## Testing guidance
 


### PR DESCRIPTION
## Summary
- update AGENTS.md to make Node 22+ the compatibility floor for agent work
- align the guidance with package engines, README, CI, and existing changelog notes

## Testing
- Not run; documentation-only change.