### PR TITLE
[codex] Rename canonical CLI binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- The canonical CLI binary is now `librus-sdk`; the previous `librus` binary
+  remains as a deprecated compatibility alias and prints a warning before
+  delegating.
+
 ## [0.4.4] - 2026-05-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -44,10 +44,13 @@ npm install librus-sdk
 Use the CLI without installing it globally:
 
 ```bash
-npx librus --version
-npx librus children list
-npx librus grades list --child <id-or-login>
+npm exec --package librus-sdk -- librus-sdk --version
+npm exec --package librus-sdk -- librus-sdk children list
+npm exec --package librus-sdk -- librus-sdk grades list --child <id-or-login>
 ```
+
+The canonical CLI binary is `librus-sdk`. A deprecated `librus` alias remains
+temporarily for compatibility and prints a warning before delegating.
 
 The package also ships a generated [`openapi.json`](./openapi.json) for the
 SDK-supported child-scoped `https://api.librus.pl/3.0` surface, so non-TypeScript
@@ -222,8 +225,8 @@ model and error modules under `src/sdk/models/`.
 
 Root CLI commands:
 
-- `librus --help`
-- `librus --version`
+- `librus-sdk --help`
+- `librus-sdk --version`
 
 Every leaf command supports `--format <text|json>`. Child-scoped commands use
 `--child <id-or-login>` to select the linked child account by numeric id or by
@@ -321,12 +324,12 @@ SDK and CLI now add diagnostics under `error.details`:
 - `requiredScope: "messages"`
 - `scopePresent` when `Auth/TokenInfo` exposes scopes for the same child token
 - `tokenScopes` when those scopes are readable
-- `hint` pointing to `librus auth token-info --child <id-or-login>`
+- `hint` pointing to `librus-sdk auth token-info --child <id-or-login>`
 
 Use the auth helper directly when you need to compare child tokens:
 
 ```bash
-npx librus auth token-info --child <id-or-login>
+npm exec --package librus-sdk -- librus-sdk auth token-info --child <id-or-login>
 ```
 
 For timeout handling, the SDK throws `LibrusNetworkTimeoutError`, and the CLI

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "valibot": "^1.3.1"
       },
       "bin": {
-        "librus": "dist/cli/main.js"
+        "librus": "dist/cli/deprecatedMain.js",
+        "librus-sdk": "dist/cli/main.js"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "main": "dist/sdk/index.js",
   "types": "dist/sdk/index.d.ts",
   "bin": {
-    "librus": "dist/cli/main.js"
+    "librus": "dist/cli/deprecatedMain.js",
+    "librus-sdk": "dist/cli/main.js"
   },
   "exports": {
     ".": {

--- a/scripts/pack-check.mjs
+++ b/scripts/pack-check.mjs
@@ -7,6 +7,7 @@ const cacheDir = join(tmpdir(), "librus-sdk-npm-cache");
 const requiredPaths = [
   "README.md",
   "LICENSE",
+  "dist/cli/deprecatedMain.js",
   "dist/cli/main.js",
   "dist/sdk/index.js",
 ];

--- a/src/cli/deprecatedMain.ts
+++ b/src/cli/deprecatedMain.ts
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+
+import {
+  createDefaultCliContext,
+  isCliEntryPoint,
+  loadCliEnvironment,
+  runCli,
+} from "./main.js";
+import type { CliContext } from "./commands/common.js";
+
+export const DEPRECATED_LIBRUS_BINARY_WARNING =
+  'Warning: the "librus" binary is deprecated; use "librus-sdk" instead.\n';
+
+export async function runDeprecatedLibrusCli(
+  argv = process.argv,
+  context: CliContext = createDefaultCliContext(),
+): Promise<number> {
+  context.stderr.write(DEPRECATED_LIBRUS_BINARY_WARNING);
+  return runCli(argv, context);
+}
+
+if (isCliEntryPoint(process.argv, import.meta.url)) {
+  loadCliEnvironment();
+  const exitCode = await runDeprecatedLibrusCli(
+    process.argv,
+    createDefaultCliContext(),
+  );
+  process.exitCode = exitCode;
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -48,7 +48,7 @@ export function createDefaultCliContext(): CliContext {
 export function createProgram(context: CliContext): Command {
   const program = configureCommand(
     new Command()
-      .name("librus")
+      .name("librus-sdk")
       .description("CLI for the Librus family portal flow")
       .version(packageJson.version),
     context,

--- a/src/sdk/synergia/SynergiaApiClient.ts
+++ b/src/sdk/synergia/SynergiaApiClient.ts
@@ -217,7 +217,7 @@ type SynergiaId = string | number;
 
 const MESSAGES_SCOPE = "messages";
 const MESSAGES_SCOPE_HINT =
-  "Run `librus auth token-info --child <id-or-login>` to inspect the token scopes for this child.";
+  "Run `librus-sdk auth token-info --child <id-or-login>` to inspect the token scopes for this child.";
 
 export class SynergiaApiClient {
   private readonly fetchImpl: FetchLike;

--- a/test/cli-high-value.test.ts
+++ b/test/cli-high-value.test.ts
@@ -378,7 +378,7 @@ describe("runCli high-value commands", () => {
                   requiredScope: "messages",
                   scopePresent: false,
                   tokenScopes: ["grades", "attendance"],
-                  hint: "Run `librus auth token-info --child <id-or-login>` to inspect the token scopes for this child.",
+                  hint: "Run `librus-sdk auth token-info --child <id-or-login>` to inspect the token scopes for this child.",
                 },
               );
             },

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -18,6 +18,10 @@ import {
   runCli,
 } from "../src/cli/main.js";
 import {
+  DEPRECATED_LIBRUS_BINARY_WARNING,
+  runDeprecatedLibrusCli,
+} from "../src/cli/deprecatedMain.js";
+import {
   LibrusSdkError,
   LibrusNetworkTimeoutError,
   type ChildAccount,
@@ -26,7 +30,7 @@ import {
 
 const packageJson = JSON.parse(
   readFileSync(new URL("../package.json", import.meta.url), "utf8"),
-) as { version: string };
+) as { bin: Record<string, string>; version: string };
 
 function createChild(overrides: Partial<ChildAccount> = {}): ChildAccount {
   return {
@@ -67,6 +71,13 @@ function withJsonFormat(argv: string[]): string[] {
 }
 
 describe("runCli", () => {
+  it("exposes the canonical and deprecated CLI binaries", () => {
+    expect(packageJson.bin).toEqual({
+      librus: "dist/cli/deprecatedMain.js",
+      "librus-sdk": "dist/cli/main.js",
+    });
+  });
+
   it("writes text output by default", async () => {
     let stdout = "";
     let stderr = "";
@@ -122,7 +133,7 @@ describe("runCli", () => {
 
     expect(exitCode).toBe(0);
     expect(stderr).toBe("");
-    expect(stdout).toContain("Usage: librus");
+    expect(stdout).toContain("Usage: librus-sdk");
   });
 
   it("prints root help and exits successfully for --help", async () => {
@@ -137,7 +148,7 @@ describe("runCli", () => {
 
     expect(exitCode).toBe(0);
     expect(stderr).toBe("");
-    expect(stdout).toContain("Usage: librus");
+    expect(stdout).toContain("Usage: librus-sdk");
   });
 
   it("prints the package version and exits successfully for --version", async () => {
@@ -153,6 +164,39 @@ describe("runCli", () => {
     expect(exitCode).toBe(0);
     expect(stderr).toBe("");
     expect(stdout.trim()).toBe(packageJson.version);
+  });
+
+  it("does not warn when the canonical CLI entrypoint runs", async () => {
+    let stdout = "";
+    let stderr = "";
+    const exitCode = await runCli(["node", "librus-sdk", "children", "list"], {
+      stdout: { write: (chunk) => (stdout += chunk) },
+      stderr: { write: (chunk) => (stderr += chunk) },
+      createSession: () => createSessionStub() as never,
+      outputWidth: 80,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Response");
+    expect(stderr).toBe("");
+  });
+
+  it("warns and delegates when the deprecated librus binary runs", async () => {
+    let stdout = "";
+    let stderr = "";
+    const exitCode = await runDeprecatedLibrusCli(
+      ["node", "librus", "children", "list"],
+      {
+        stdout: { write: (chunk) => (stdout += chunk) },
+        stderr: { write: (chunk) => (stderr += chunk) },
+        createSession: () => createSessionStub() as never,
+        outputWidth: 80,
+      },
+    );
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Response");
+    expect(stderr).toBe(DEPRECATED_LIBRUS_BINARY_WARNING);
   });
 
   it("writes stable JSON errors to stderr for --format json", async () => {

--- a/test/synergia-messages.test.ts
+++ b/test/synergia-messages.test.ts
@@ -260,7 +260,7 @@ describe("SynergiaApiClient message methods", () => {
         requiredScope: "messages",
         scopePresent: false,
         tokenScopes: ["grades", "attendance"],
-        hint: "Run `librus auth token-info --child <id-or-login>` to inspect the token scopes for this child.",
+        hint: "Run `librus-sdk auth token-info --child <id-or-login>` to inspect the token scopes for this child.",
       },
     });
     expectNthJsonGetRequest(
@@ -297,7 +297,7 @@ describe("SynergiaApiClient message methods", () => {
         requiredScope: "messages",
         scopePresent: true,
         tokenScopes: ["Messages", "Grades"],
-        hint: "Run `librus auth token-info --child <id-or-login>` to inspect the token scopes for this child.",
+        hint: "Run `librus-sdk auth token-info --child <id-or-login>` to inspect the token scopes for this child.",
       },
     });
   });
@@ -319,7 +319,7 @@ describe("SynergiaApiClient message methods", () => {
         status: 403,
         feature: "messages",
         requiredScope: "messages",
-        hint: "Run `librus auth token-info --child <id-or-login>` to inspect the token scopes for this child.",
+        hint: "Run `librus-sdk auth token-info --child <id-or-login>` to inspect the token scopes for this child.",
       },
     });
   });


### PR DESCRIPTION
## Summary

- make `librus-sdk` the canonical CLI binary
- keep `librus` as a deprecated compatibility alias with a stderr warning
- update docs, diagnostics, package metadata, pack checks, and tests

## Validation

- `npm test`
- `npm run build`
- `npm run pack:check`
- `npm run lint`

Note: SSH push failed because the local SSH key is not accepted by GitHub, so the branch was pushed over HTTPS without changing the repository remote.