### PR TITLE
[codex] Add mobile headers to Synergia requests

### DIFF
--- a/src/sdk/synergia/request.ts
+++ b/src/sdk/synergia/request.ts
@@ -13,6 +13,22 @@ export interface SynergiaRequestOptions {
   query?: SynergiaQuery;
 }
 
+const LIBRUS_MOBILE_ORIGIN = "app://librus";
+const LIBRUS_MOBILE_USER_AGENT =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 LibrusMobileApp";
+
+function buildSynergiaHeaders(
+  accessToken: string,
+  extraHeaders: HeadersInit = {},
+): HeadersInit {
+  return {
+    origin: LIBRUS_MOBILE_ORIGIN,
+    "user-agent": LIBRUS_MOBILE_USER_AGENT,
+    authorization: `Bearer ${accessToken}`,
+    ...extraHeaders,
+  };
+}
+
 function normalizeApiBaseUrl(apiBaseUrl: string): string {
   return apiBaseUrl.endsWith("/") ? apiBaseUrl : `${apiBaseUrl}/`;
 }
@@ -84,10 +100,9 @@ export async function getJson<
   const endpoint = buildEndpoint(apiBaseUrl, path, options.query);
   const response = await fetchImpl(endpoint, {
     method: "GET",
-    headers: {
+    headers: buildSynergiaHeaders(accessToken, {
       accept: "application/json",
-      authorization: `Bearer ${accessToken}`,
-    },
+    }),
   });
 
   if (!response.ok) {
@@ -107,9 +122,7 @@ export async function getBinary(
   const endpoint = buildEndpoint(apiBaseUrl, path, options.query);
   const response = await fetchImpl(endpoint, {
     method: "GET",
-    headers: {
-      authorization: `Bearer ${accessToken}`,
-    },
+    headers: buildSynergiaHeaders(accessToken),
   });
 
   if (!response.ok) {

--- a/test/fetchAssertions.ts
+++ b/test/fetchAssertions.ts
@@ -6,6 +6,9 @@ interface FetchMockLike {
   };
 }
 
+const LIBRUS_MOBILE_USER_AGENT =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 LibrusMobileApp";
+
 export function expectJsonGetRequest(
   fetchMock: FetchMockLike,
   expectedUrl: string,
@@ -21,6 +24,8 @@ export function expectNthJsonGetRequest(
   expectNthGetRequest(fetchMock, callNumber, expectedUrl, {
     accept: "application/json",
     authorization: "Bearer token",
+    origin: "app://librus",
+    "user-agent": LIBRUS_MOBILE_USER_AGENT,
   });
 }
 
@@ -38,6 +43,8 @@ export function expectNthBinaryGetRequest(
 ): void {
   expectNthGetRequest(fetchMock, callNumber, expectedUrl, {
     authorization: "Bearer token",
+    origin: "app://librus",
+    "user-agent": LIBRUS_MOBILE_USER_AGENT,
   });
 }
 

--- a/test/synergia-request.test.ts
+++ b/test/synergia-request.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it, vi } from "vitest";
 
 import { buildEndpoint, getBinary } from "../src/sdk/synergia/request.js";
 
+const LIBRUS_MOBILE_USER_AGENT =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 LibrusMobileApp";
+
 describe("Synergia request helpers", () => {
   it("builds endpoints without query params", () => {
     expect(buildEndpoint("https://api.librus.pl/3.0", "/Me")).toBe(
@@ -52,6 +55,8 @@ describe("Synergia request helpers", () => {
         method: "GET",
         headers: {
           authorization: "Bearer token",
+          origin: "app://librus",
+          "user-agent": LIBRUS_MOBILE_USER_AGENT,
         },
       },
     );


### PR DESCRIPTION
## Summary
- add mobile app origin and user-agent headers to Synergia API requests
- keep JSON accept handling scoped to JSON requests while binary requests only get the mobile parity headers
- update request assertion helpers and binary request coverage

## Validation
- npm run lint
- npm run format:check
- npm run build
- npm test
- npm run pack:check