### PR TITLE
[codex] Release 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-05-13
+
 ### Added
 
+- The SDK now exposes an experimental `BffApiClient` plus
+  `LibrusSession.forChildBff()` for reading
+  `https://testbff.librus.pl/v1/Messages` with child-scoped access tokens.
 - `messages bff-list` now exposes the experimental BFF inbox message payload
   through the CLI.
 
@@ -16,6 +21,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - The canonical CLI binary is now `librus-sdk`; the previous `librus` binary
   remains as a deprecated compatibility alias and prints a warning before
   delegating.
+- Synergia API requests now align message-related mobile headers with the
+  Librus mobile app, including `Origin: app://librus`.
+- `messages list` now sends the mobile-app query parity options
+  `alternativeBody`, `changeNewLine`, `getAllTypes`, `page`, and `limit` by
+  default, with CLI/SDK options for overriding them.
 
 ## [0.4.4] - 2026-05-03
 

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.3",
   "info": {
     "title": "Librus Synergia API (SDK-supported subset)",
-    "version": "0.4.4",
+    "version": "0.5.0",
     "description": "Best-effort OpenAPI document generated from the SDK's supported child-scoped Synergia GET surface. Authentication starts on portal.librus.pl; this document covers the subsequent bearer-token calls against api.librus.pl/3.0."
   },
   "servers": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "librus-sdk",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "librus-sdk",
-      "version": "0.4.4",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@valibot/to-json-schema": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librus-sdk",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "description": "TypeScript SDK and CLI for the Librus family portal flow.",
   "author": "Andrey Koltsov",
   "repository": {


### PR DESCRIPTION
## Summary
- bump package version to 0.5.0
- regenerate OpenAPI metadata for 0.5.0
- move Unreleased notes into the 0.5.0 changelog section

## Validation
- npm run validate
- npm run openapi:check
- node ./scripts/extract-release-notes.mjs 0.5.0
- node --env-file=/Users/andreykoltsov/work/librus-sdk/.env.integration.local --test test/integration/cli.integration.test.mjs (68/68)
- node --env-file=/Users/andreykoltsov/work/librus-sdk/.env.integration.local --test test/integration/sdk.integration.test.mjs (149/149)