### PR TITLE
[codex] add wiadomosci message backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Session-created SDK clients and CLI message read commands now use the
+  portal-authenticated `wiadomosci.librus.pl` inbox API for `messages list`,
+  `messages get`, and `messages unread`.
+
 ## [0.5.0] - 2026-05-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -159,6 +159,14 @@ Attachment-style methods such as `getHomeworkAssignmentAttachment(id)`,
 `getMessageAttachment(id)`, and `getPlannedLessonAttachment(id)` return
 `SynergiaBinaryResult` with `{ data, contentType, contentDisposition }`.
 
+When a `SynergiaApiClient` is created through `LibrusSession.forChild()`,
+message reads use the portal-authenticated `https://wiadomosci.librus.pl/api`
+inbox backend by default for `listMessages()`, `getMessage(id)`, and
+`getUnreadMessages()`. Other child-scoped reads, message receiver groups, and
+message attachment downloads continue to use `https://api.librus.pl/3.0`.
+Direct `new SynergiaApiClient(token)` construction keeps using API 3.0 for all
+methods unless a custom message backend is supplied.
+
 `BffApiClient` currently exposes the research-oriented `listMessages()` method
 for `GET https://testbff.librus.pl/v1/Messages`. It uses the selected child's
 Synergia access token as `x-zse-authorization` and returns the raw
@@ -320,10 +328,11 @@ Current codes emitted by the SDK and CLI:
 
 ### Troubleshooting
 
-`messages` reads can fail with HTTP `403` even when other child-scoped
-endpoints such as `grades list` still work. This appears to depend on the
-current child account's effective message access rather than on the overall
-portal login flow.
+Direct API 3.0 `messages` reads can fail with HTTP `403` even when other
+child-scoped endpoints such as `grades list` still work. Session-created SDK
+clients and CLI `messages list`, `messages get`, and `messages unread` use the
+portal-authenticated `wiadomosci.librus.pl` inbox backend by default to avoid
+that mobile-addons gate.
 
 When a `/Messages` request returns `API_REQUEST_FAILED` with `status: 403`, the
 SDK and CLI now add diagnostics under `error.details`:

--- a/src/sdk/LibrusSession.ts
+++ b/src/sdk/LibrusSession.ts
@@ -8,6 +8,10 @@ import {
   type SynergiaApiClientOptions,
 } from "./synergia/SynergiaApiClient.js";
 import {
+  WiadomosciMessagesClient,
+  type WiadomosciMessagesClientOptions,
+} from "./wiadomosci/WiadomosciMessagesClient.js";
+import {
   LibrusConfigurationError,
   LibrusSdkError,
   type ChildAccount,
@@ -50,6 +54,10 @@ export interface LibrusSessionOptions {
   portalClientOptions?: PortalClientOptions;
   bffClientOptions?: BffApiClientOptions;
   synergiaClientOptions?: SynergiaApiClientOptions;
+  wiadomosciClientOptions?: Omit<
+    WiadomosciMessagesClientOptions,
+    "ensurePortalLogin" | "portalClient"
+  >;
   requestTimeoutMs?: number;
 }
 
@@ -58,6 +66,12 @@ export class LibrusSession {
   private readonly portalClient: PortalClient;
   private readonly bffClientOptions: BffApiClientOptions | undefined;
   private readonly synergiaClientOptions: SynergiaApiClientOptions | undefined;
+  private readonly wiadomosciClientOptions:
+    | Omit<
+        WiadomosciMessagesClientOptions,
+        "ensurePortalLogin" | "portalClient"
+      >
+    | undefined;
   private accountsCache?: SynergiaAccountsResponse;
 
   constructor(options: LibrusSessionOptions) {
@@ -94,12 +108,23 @@ export class LibrusSession {
               requestTimeoutMs,
             }
           : { requestTimeoutMs };
+    const wiadomosciClientOptions =
+      options.wiadomosciClientOptions?.requestTimeoutMs !== undefined ||
+      requestTimeoutMs === undefined
+        ? options.wiadomosciClientOptions
+        : options.wiadomosciClientOptions
+          ? {
+              ...options.wiadomosciClientOptions,
+              requestTimeoutMs,
+            }
+          : { requestTimeoutMs };
 
     this.credentials = options.credentials;
     this.portalClient =
       options.portalClient ?? new PortalClient(portalClientOptions);
     this.bffClientOptions = bffClientOptions;
     this.synergiaClientOptions = synergiaClientOptions;
+    this.wiadomosciClientOptions = wiadomosciClientOptions;
   }
 
   static fromEnv(env: NodeJS.ProcessEnv = process.env): LibrusSession {
@@ -196,7 +221,18 @@ export class LibrusSession {
       typeof selectorOrChild === "string"
         ? await this.resolveChild(selectorOrChild)
         : selectorOrChild;
-    return new SynergiaApiClient(child.accessToken, this.synergiaClientOptions);
+    const messageBackend =
+      this.synergiaClientOptions?.messageBackend ??
+      new WiadomosciMessagesClient(child, {
+        ...this.wiadomosciClientOptions,
+        ensurePortalLogin: () => this.login(),
+        portalClient: this.portalClient,
+      });
+
+    return new SynergiaApiClient(child.accessToken, {
+      ...this.synergiaClientOptions,
+      messageBackend,
+    });
   }
 
   async forChildBff(

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -3,4 +3,5 @@ export { LibrusSession } from "./LibrusSession.js";
 export { generateOpenApiDocument } from "./openapi.js";
 export { PortalClient } from "./portal/PortalClient.js";
 export { SynergiaApiClient } from "./synergia/SynergiaApiClient.js";
+export { WiadomosciMessagesClient } from "./wiadomosci/WiadomosciMessagesClient.js";
 export * from "./models/index.js";

--- a/src/sdk/models/synergia/messages.ts
+++ b/src/sdk/models/synergia/messages.ts
@@ -2,7 +2,7 @@ import type { ApiRef, JsonObject } from "../common.js";
 
 import type { SynergiaResponseEnvelope } from "./common.js";
 
-type SynergiaId = string | number;
+export type SynergiaId = string | number;
 
 export interface ListMessagesOptions {
   afterId?: SynergiaId;
@@ -42,4 +42,10 @@ export interface MessageReceiverGroupsResponse extends SynergiaResponseEnvelope 
 
 export interface MessageReceiverGroupResponse extends SynergiaResponseEnvelope {
   ReceiversGroup: MessageReceiverGroup | MessageReceiverGroup[] | null;
+}
+
+export interface MessageReadBackend {
+  listMessages(options?: ListMessagesOptions): Promise<MessagesResponse>;
+  getMessage(id: SynergiaId): Promise<MessageResponse>;
+  getUnreadMessages(): Promise<UnreadMessagesResponse>;
 }

--- a/src/sdk/portal/PortalClient.ts
+++ b/src/sdk/portal/PortalClient.ts
@@ -4,6 +4,7 @@ import type { FetchLike } from "../models/common.js";
 import {
   LibrusApiError,
   LibrusAuthenticationError,
+  type ChildAccount,
   type PortalCredentials,
   type PortalMe,
   type SynergiaAccountsResponse,
@@ -15,6 +16,7 @@ import {
 import type { BaseIssue, BaseSchema, InferOutput } from "valibot";
 import {
   portalMeSchema,
+  childAccountSchema,
   synergiaAccountsResponseSchema,
 } from "../validation/portal.js";
 import { parseApiResponse } from "../validation/responseValidation.js";
@@ -123,6 +125,15 @@ export class PortalClient {
     };
   }
 
+  async getFreshSynergiaAccount(login: string): Promise<ChildAccount> {
+    return normalizeChildAccount(
+      await this.getPortalJson(
+        `/SynergiaAccounts/fresh/${encodeURIComponent(login)}`,
+        childAccountSchema,
+      ),
+    );
+  }
+
   isLoggedIn(): boolean {
     return this.loggedIn;
   }
@@ -152,4 +163,16 @@ export class PortalClient {
   private buildUrl(baseUrl: string, path: string): string {
     return new URL(path, baseUrl).toString();
   }
+}
+
+interface RawChildAccount extends Omit<ChildAccount, "scopes"> {
+  scopes?: string[] | "" | undefined;
+}
+
+function normalizeChildAccount(account: RawChildAccount): ChildAccount {
+  const { scopes, ...accountWithoutScopes } = account;
+
+  return Array.isArray(scopes)
+    ? { ...accountWithoutScopes, scopes }
+    : accountWithoutScopes;
 }

--- a/src/sdk/synergia/SynergiaApiClient.ts
+++ b/src/sdk/synergia/SynergiaApiClient.ts
@@ -63,6 +63,7 @@ import type {
 import type { SynergiaMeResponse } from "../models/synergia/me.js";
 import type {
   ListMessagesOptions,
+  MessageReadBackend,
   MessageReceiverGroupResponse,
   MessageReceiverGroupsResponse,
   MessageResponse,
@@ -210,6 +211,7 @@ import {
 export interface SynergiaApiClientOptions {
   fetch?: FetchLike;
   apiBaseUrl?: string;
+  messageBackend?: MessageReadBackend;
   requestTimeoutMs?: number;
 }
 
@@ -223,6 +225,7 @@ export class SynergiaApiClient {
   private readonly fetchImpl: FetchLike;
   private readonly apiBaseUrl: string;
   private readonly accessToken: string;
+  private readonly messageBackend: MessageReadBackend | undefined;
   private readonly requestTimeoutMs: number;
 
   constructor(accessToken: string, options: SynergiaApiClientOptions = {}) {
@@ -233,6 +236,7 @@ export class SynergiaApiClient {
       this.requestTimeoutMs,
     );
     this.apiBaseUrl = options.apiBaseUrl ?? "https://api.librus.pl/3.0";
+    this.messageBackend = options.messageBackend;
   }
 
   private getJson<
@@ -680,6 +684,10 @@ export class SynergiaApiClient {
   }
 
   listMessages(options: ListMessagesOptions = {}): Promise<MessagesResponse> {
+    if (this.messageBackend) {
+      return this.messageBackend.listMessages(options);
+    }
+
     const {
       afterId,
       alternativeBody = true,
@@ -704,6 +712,10 @@ export class SynergiaApiClient {
   }
 
   getMessage(id: SynergiaId): Promise<MessageResponse> {
+    if (this.messageBackend) {
+      return this.messageBackend.getMessage(id);
+    }
+
     return this.withMessageAccessDiagnostics(() =>
       this.getJson(
         `/Messages/${encodeURIComponent(String(id))}`,
@@ -713,6 +725,10 @@ export class SynergiaApiClient {
   }
 
   getUnreadMessages(): Promise<UnreadMessagesResponse> {
+    if (this.messageBackend) {
+      return this.messageBackend.getUnreadMessages();
+    }
+
     return this.withMessageAccessDiagnostics(() =>
       this.getJson("/Messages/Unread", unreadMessagesResponseSchema),
     );

--- a/src/sdk/validation/portal.ts
+++ b/src/sdk/validation/portal.ts
@@ -8,7 +8,7 @@ export const portalMeSchema = v.looseObject({
   subscription: v.optional(unknownRecordSchema),
 });
 
-const childAccountSchema = v.looseObject({
+export const childAccountSchema = v.looseObject({
   accessToken: v.string(),
   accountIdentifier: v.string(),
   group: v.string(),

--- a/src/sdk/wiadomosci.ts
+++ b/src/sdk/wiadomosci.ts
@@ -1,0 +1,1 @@
+export * from "./wiadomosci/WiadomosciMessagesClient.js";

--- a/src/sdk/wiadomosci/WiadomosciMessagesClient.ts
+++ b/src/sdk/wiadomosci/WiadomosciMessagesClient.ts
@@ -1,0 +1,392 @@
+import { Buffer } from "node:buffer";
+
+import { createSessionFetch } from "../auth/sessionFetch.js";
+import type { FetchLike, JsonObject } from "../models/common.js";
+import { LibrusApiError } from "../models/errors.js";
+import type { ChildAccount } from "../models/portal.js";
+import type {
+  ListMessagesOptions,
+  Message,
+  MessageReadBackend,
+  MessageResponse,
+  MessagesResponse,
+  SynergiaId,
+  UnreadMessagesResponse,
+} from "../models/synergia/messages.js";
+import { PortalClient } from "../portal/PortalClient.js";
+import {
+  resolveRequestTimeoutMs,
+  wrapFetchWithTimeout,
+} from "../requestTimeout.js";
+import { parseApiResponse } from "../validation/responseValidation.js";
+import {
+  messageResponseSchema,
+  messagesResponseSchema,
+  unreadMessagesResponseSchema,
+} from "../validation/synergia/messages.js";
+
+const LIBRUS_MOBILE_USER_AGENT =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 LibrusMobileApp";
+const SYNERGIA_USER_AGENT =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Gecko/20100101 Firefox/62.0";
+const DEFAULT_API_BASE_URL = "https://api.librus.pl/2.0";
+const DEFAULT_SYNERGIA_BASE_URL = "https://synergia.librus.pl";
+const DEFAULT_WIADOMOSCI_BASE_URL = "https://wiadomosci.librus.pl";
+
+interface AutoLoginTokenResponse {
+  Token?: unknown;
+}
+
+interface WiadomosciListResponse {
+  data?: unknown;
+}
+
+interface WiadomosciDetailResponse {
+  data?: unknown;
+}
+
+interface WiadomosciUnreadResponse {
+  data?: unknown;
+}
+
+export interface WiadomosciMessagesClientOptions {
+  apiBaseUrl?: string;
+  ensurePortalLogin?: () => Promise<void>;
+  fetch?: FetchLike;
+  portalClient: PortalClient;
+  requestTimeoutMs?: number;
+  synergiaBaseUrl?: string;
+  wiadomosciBaseUrl?: string;
+}
+
+export class WiadomosciMessagesClient implements MessageReadBackend {
+  private authenticated = false;
+  private readonly apiBaseUrl: string;
+  private readonly childLogin: string;
+  private readonly ensurePortalLogin: () => Promise<void>;
+  private readonly fetchImpl: FetchLike;
+  private readonly portalClient: PortalClient;
+  private readonly synergiaBaseUrl: string;
+  private readonly wiadomosciBaseUrl: string;
+
+  constructor(child: ChildAccount, options: WiadomosciMessagesClientOptions) {
+    const requestTimeoutMs = resolveRequestTimeoutMs(options.requestTimeoutMs);
+    const sessionFetch = createSessionFetch(options.fetch ?? fetch);
+
+    this.apiBaseUrl = options.apiBaseUrl ?? DEFAULT_API_BASE_URL;
+    this.childLogin = child.login;
+    this.ensurePortalLogin = options.ensurePortalLogin ?? (async () => {});
+    this.fetchImpl = wrapFetchWithTimeout(sessionFetch.fetch, requestTimeoutMs);
+    this.portalClient = options.portalClient;
+    this.synergiaBaseUrl = options.synergiaBaseUrl ?? DEFAULT_SYNERGIA_BASE_URL;
+    this.wiadomosciBaseUrl =
+      options.wiadomosciBaseUrl ?? DEFAULT_WIADOMOSCI_BASE_URL;
+  }
+
+  async listMessages(
+    options: ListMessagesOptions = {},
+  ): Promise<MessagesResponse> {
+    const { page = 1, limit = 300, afterId } = options;
+    const endpoint = this.buildWiadomosciEndpoint("/api/inbox/messages", {
+      page,
+      limit,
+      afterId,
+    });
+    const response =
+      await this.getWiadomosciJson<WiadomosciListResponse>(endpoint);
+    const payload = {
+      Messages: Array.isArray(response.data)
+        ? response.data.map((item) =>
+            normalizeMessage(item, this.wiadomosciBaseUrl),
+          )
+        : [],
+      Resources: {},
+      Url: endpoint,
+    };
+
+    return parseApiResponse(messagesResponseSchema, payload, endpoint);
+  }
+
+  async getMessage(id: SynergiaId): Promise<MessageResponse> {
+    const endpoint = this.buildWiadomosciEndpoint(
+      `/api/inbox/messages/${encodeURIComponent(String(id))}`,
+    );
+    const response =
+      await this.getWiadomosciJson<WiadomosciDetailResponse>(endpoint);
+    const payload = {
+      Message: normalizeMessage(response.data, this.wiadomosciBaseUrl),
+      Resources: {},
+      Url: endpoint,
+    };
+
+    return parseApiResponse(messageResponseSchema, payload, endpoint);
+  }
+
+  async getUnreadMessages(): Promise<UnreadMessagesResponse> {
+    const endpoint = this.buildWiadomosciEndpoint(
+      "/api/inbox/unreadMessagesCount",
+    );
+    const response =
+      await this.getWiadomosciJson<WiadomosciUnreadResponse>(endpoint);
+    const payload = {
+      UnreadMessages: normalizeUnreadCount(response.data),
+      Resources: {},
+      Url: endpoint,
+    };
+
+    return parseApiResponse(unreadMessagesResponseSchema, payload, endpoint);
+  }
+
+  private async authenticate(): Promise<void> {
+    await this.ensurePortalLogin();
+
+    const account = await this.portalClient.getFreshSynergiaAccount(
+      this.childLogin,
+    );
+    const token = await this.getAutoLoginToken(account.accessToken);
+
+    await this.getHtml(
+      this.buildSynergiaEndpoint(
+        `/loguj/token/${encodeURIComponent(token)}/przenies/uczen/widok/centrum_powiadomien`,
+      ),
+      LIBRUS_MOBILE_USER_AGENT,
+      "Wiadomosci Synergia login failed",
+      this.buildSynergiaEndpoint(
+        "/loguj/token/REDACTED/przenies/uczen/widok/centrum_powiadomien",
+      ),
+    );
+    await this.getHtml(
+      this.buildSynergiaEndpoint("/wiadomosci3"),
+      SYNERGIA_USER_AGENT,
+      "Wiadomosci activation failed",
+    );
+
+    this.authenticated = true;
+  }
+
+  private async getAutoLoginToken(accessToken: string): Promise<string> {
+    const endpoint = this.buildApiEndpoint("/AutoLoginToken");
+    const response = await this.fetchImpl(endpoint, {
+      method: "POST",
+      headers: {
+        accept: "application/json",
+        authorization: `Bearer ${accessToken}`,
+        "user-agent": LIBRUS_MOBILE_USER_AGENT,
+      },
+    });
+
+    if (!response.ok) {
+      await consumeResponse(response);
+      throw new LibrusApiError(
+        endpoint,
+        response.status,
+        "Wiadomosci authentication failed",
+      );
+    }
+
+    const payload = (await response.json()) as AutoLoginTokenResponse;
+
+    if (typeof payload.Token !== "string" || payload.Token.length === 0) {
+      throw new LibrusApiError(
+        endpoint,
+        200,
+        "Wiadomosci authentication response was invalid",
+      );
+    }
+
+    return payload.Token;
+  }
+
+  private async getHtml(
+    endpoint: string,
+    userAgent: string,
+    failureMessage: string,
+    errorEndpoint = endpoint,
+  ): Promise<void> {
+    const response = await this.fetchImpl(endpoint, {
+      method: "GET",
+      headers: {
+        "user-agent": userAgent,
+      },
+    });
+
+    if (!response.ok) {
+      await consumeResponse(response);
+      throw new LibrusApiError(errorEndpoint, response.status, failureMessage);
+    }
+
+    await consumeResponse(response);
+  }
+
+  private async getWiadomosciJson<T>(endpoint: string): Promise<T> {
+    return this.getWiadomosciJsonWithRetry(endpoint, true);
+  }
+
+  private async getWiadomosciJsonWithRetry<T>(
+    endpoint: string,
+    retryAfterUnauthorized: boolean,
+  ): Promise<T> {
+    if (!this.authenticated) {
+      await this.authenticate();
+    }
+
+    const response = await this.fetchImpl(endpoint, {
+      method: "GET",
+      headers: {
+        accept: "application/json",
+        "user-agent": SYNERGIA_USER_AGENT,
+      },
+    });
+
+    if (response.status === 401 && retryAfterUnauthorized) {
+      await consumeResponse(response);
+      this.authenticated = false;
+      return this.getWiadomosciJsonWithRetry(endpoint, false);
+    }
+
+    if (!response.ok) {
+      await consumeResponse(response);
+      throw new LibrusApiError(
+        endpoint,
+        response.status,
+        "Wiadomosci API request failed",
+      );
+    }
+
+    return (await response.json()) as T;
+  }
+
+  private buildApiEndpoint(path: string): string {
+    return buildEndpoint(this.apiBaseUrl, path);
+  }
+
+  private buildSynergiaEndpoint(path: string): string {
+    return buildEndpoint(this.synergiaBaseUrl, path);
+  }
+
+  private buildWiadomosciEndpoint(
+    path: string,
+    query: Record<string, unknown> = {},
+  ): string {
+    const endpoint = new URL(buildEndpoint(this.wiadomosciBaseUrl, path));
+
+    for (const [key, value] of Object.entries(query)) {
+      if (
+        typeof value === "string" ||
+        typeof value === "number" ||
+        typeof value === "boolean"
+      ) {
+        endpoint.searchParams.set(key, String(value));
+      }
+    }
+
+    return endpoint.toString();
+  }
+}
+
+function buildEndpoint(baseUrl: string, path: string): string {
+  return new URL(
+    path.replace(/^\/+/, ""),
+    ensureTrailingSlash(baseUrl),
+  ).toString();
+}
+
+function ensureTrailingSlash(url: string): string {
+  return url.endsWith("/") ? url : `${url}/`;
+}
+
+function normalizeMessage(value: unknown, wiadomosciBaseUrl: string): Message {
+  const raw = isJsonObject(value) ? value : {};
+  const id = raw.messageId ?? raw.Id;
+  const senderId = raw.senderId;
+  const receiverId = getReceiverId(raw);
+  const normalized: JsonObject = {
+    ...raw,
+    Id: typeof id === "string" || typeof id === "number" ? id : "",
+    Body: normalizeMessageBody(raw),
+    ReadDate: normalizeDate(raw.readDate ?? raw.ReadDate),
+    SendDate: normalizeDate(raw.sendDate ?? raw.SendDate),
+    Subject: raw.topic ?? raw.Subject,
+  };
+
+  if (typeof senderId === "string" || typeof senderId === "number") {
+    normalized.Sender = {
+      Id: senderId,
+      Url: buildEndpoint(wiadomosciBaseUrl, `/api/users/${senderId}`),
+    };
+  }
+
+  if (typeof receiverId === "string" || typeof receiverId === "number") {
+    normalized.Receiver = {
+      Id: receiverId,
+      Url: buildEndpoint(wiadomosciBaseUrl, `/api/users/${receiverId}`),
+    };
+  }
+
+  return normalized as Message;
+}
+
+function getReceiverId(raw: JsonObject): unknown {
+  const receiver = raw.receiver;
+
+  return isJsonObject(receiver) ? receiver.id : raw.receiverId;
+}
+
+function normalizeMessageBody(raw: JsonObject): unknown {
+  if (typeof raw.Message === "string") {
+    return decodeMessageXml(raw.Message) ?? raw.Message;
+  }
+
+  return raw.content ?? raw.Body;
+}
+
+function decodeMessageXml(value: string): string | null {
+  let decoded: string;
+
+  try {
+    decoded = Buffer.from(value, "base64").toString("utf8");
+  } catch {
+    return null;
+  }
+
+  if (!decoded.includes("<Message")) {
+    return null;
+  }
+
+  const content = /<Content><!\[CDATA\[([\s\S]*?)\]\]><\/Content>/.exec(
+    decoded,
+  );
+
+  return content?.[1] ?? decoded;
+}
+
+function normalizeDate(value: unknown): unknown {
+  if (typeof value !== "string") {
+    return value;
+  }
+
+  const isoLikeValue = value.includes("T") ? value : value.replace(" ", "T");
+  const timestamp = Date.parse(isoLikeValue);
+
+  return Number.isNaN(timestamp) ? value : timestamp;
+}
+
+function normalizeUnreadCount(value: unknown): number {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === "string" && /^\d+$/.test(value)) {
+    return Number(value);
+  }
+
+  return 0;
+}
+
+function isJsonObject(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function consumeResponse(response: Response): Promise<void> {
+  await response.arrayBuffer();
+}

--- a/test/integration/helpers/cli.mjs
+++ b/test/integration/helpers/cli.mjs
@@ -258,6 +258,24 @@ function summarizeSuccess(args, payload) {
   }
 
   if (commandName === "messages") {
+    const usesWiadomosci =
+      subcommandName === "list" ||
+      subcommandName === "get" ||
+      subcommandName === "unread";
+    const url = payload.data?.Url;
+
+    if (
+      usesWiadomosci &&
+      (typeof url !== "string" ||
+        !url.startsWith("https://wiadomosci.librus.pl/api/"))
+    ) {
+      return {
+        ok: false,
+        child: payload.child ? summarizeChild(payload.child) : null,
+        errorMessage: `Expected wiadomosci message API URL, got ${url}`,
+      };
+    }
+
     return {
       ok: true,
       child: payload.child ? summarizeChild(payload.child) : null,

--- a/test/integration/helpers/sdk.mjs
+++ b/test/integration/helpers/sdk.mjs
@@ -1,3 +1,4 @@
+import assert from "node:assert/strict";
 import { accessSync, constants } from "node:fs";
 import { fileURLToPath } from "node:url";
 
@@ -65,6 +66,25 @@ function summarizeArrayResponse(payload, key) {
   return {
     count: Array.isArray(payload[key]) ? payload[key].length : 0,
   };
+}
+
+function assertWiadomosciUrl(payload) {
+  assert.equal(
+    typeof payload.Url === "string" &&
+      payload.Url.startsWith("https://wiadomosci.librus.pl/api/"),
+    true,
+    `Expected wiadomosci message API URL, got ${payload.Url}`,
+  );
+}
+
+function summarizeWiadomosciArrayResponse(payload, key) {
+  assertWiadomosciUrl(payload);
+  return summarizeArrayResponse(payload, key);
+}
+
+function summarizeWiadomosciCountResponse(payload, key) {
+  assertWiadomosciUrl(payload);
+  return summarizeCountResponse(payload, key);
 }
 
 function summarizeCountResponse(payload, key) {
@@ -180,11 +200,19 @@ function arrayCheck(name, load, key) {
   };
 }
 
-function countCheck(name, load, key) {
+function wiadomosciArrayCheck(name, load, key) {
   return {
     name,
     load,
-    summarize: (payload) => summarizeCountResponse(payload, key),
+    summarize: (payload) => summarizeWiadomosciArrayResponse(payload, key),
+  };
+}
+
+function wiadomosciCountCheck(name, load, key) {
+  return {
+    name,
+    load,
+    summarize: (payload) => summarizeWiadomosciCountResponse(payload, key),
   };
 }
 
@@ -742,6 +770,7 @@ async function runMessageDetailCheck(api) {
     }
 
     const message = await api.getMessage(messageId);
+    assertWiadomosciUrl(message);
 
     return {
       ok: true,
@@ -1074,8 +1103,8 @@ const sdkChecks = [
   keysCheck("systemData", (api) => api.getSystemData()),
   objectCheck("authPhotos", (api) => api.listAuthPhotos(), "data"),
   keysCheck("authTokenInfo", (api) => api.getAuthTokenInfo()),
-  arrayCheck("messages", (api) => api.listMessages(), "Messages"),
-  countCheck(
+  wiadomosciArrayCheck("messages", (api) => api.listMessages(), "Messages"),
+  wiadomosciCountCheck(
     "unreadMessages",
     (api) => api.getUnreadMessages(),
     "UnreadMessages",

--- a/test/librus-session.test.ts
+++ b/test/librus-session.test.ts
@@ -28,6 +28,7 @@ function createPortalClientStub(
   } = {},
 ): {
   getMe: ReturnType<typeof vi.fn>;
+  getFreshSynergiaAccount: ReturnType<typeof vi.fn>;
   getSynergiaAccounts: ReturnType<typeof vi.fn>;
   login: ReturnType<typeof vi.fn>;
   portalClient: PortalClient;
@@ -43,8 +44,17 @@ function createPortalClientStub(
     accounts: options.accounts ?? [],
     lastModification: 456,
   });
+  const getFreshSynergiaAccount = vi
+    .fn()
+    .mockImplementation((login: string) =>
+      Promise.resolve(
+        options.accounts?.find((account) => account.login === login) ??
+          createChild({ accessToken: "fresh-child-token", login }),
+      ),
+    );
 
   return {
+    getFreshSynergiaAccount,
     getMe,
     getSynergiaAccounts,
     login,
@@ -52,6 +62,7 @@ function createPortalClientStub(
       isLoggedIn: () => options.isLoggedIn ?? true,
       login,
       getMe,
+      getFreshSynergiaAccount,
       getSynergiaAccounts,
     } as unknown as PortalClient,
   };
@@ -451,6 +462,52 @@ describe("LibrusSession.resolveChild", () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(grades.Grades).toEqual([]);
+  });
+
+  it("uses the wiadomosci backend for session-created message reads", async () => {
+    const child = createChild({
+      accessToken: "child-access-token",
+    });
+    const { getFreshSynergiaAccount, portalClient } = createPortalClientStub({
+      accounts: [child],
+    });
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ Token: "auto-login-token" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(new Response("", { status: 200 }))
+      .mockResolvedValueOnce(new Response("", { status: 200 }))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: [{ messageId: 1, topic: "Hello" }],
+            total: 1,
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      );
+    const session = new LibrusSession({
+      credentials: { email: "parent@example.com", password: "secret" },
+      portalClient,
+      wiadomosciClientOptions: { fetch: fetchMock },
+    });
+
+    const client = await session.forChild(child);
+    const messages = await client.listMessages({ limit: 10 });
+
+    expect(getFreshSynergiaAccount).toHaveBeenCalledWith("child-login");
+    expect(messages).toMatchObject({
+      Messages: [{ Id: 1, Subject: "Hello" }],
+      Resources: {},
+      Url: "https://wiadomosci.librus.pl/api/inbox/messages?page=1&limit=10",
+    });
   });
 
   it("creates a child-scoped BFF API client when given a child object directly", async () => {

--- a/test/portal-client.test.ts
+++ b/test/portal-client.test.ts
@@ -239,6 +239,91 @@ describe("PortalClient", () => {
     expect(response.accounts[0]).not.toHaveProperty("scopes");
   });
 
+  it("fetches a fresh child Synergia account by login", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: 10,
+          accountIdentifier: "abc",
+          group: "parent",
+          login: "child-login",
+          studentName: "Child Name",
+          accessToken: "fresh-secret",
+          state: "active",
+          scopes: ["Messages"],
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      ),
+    );
+    const client = new PortalClient({ fetch: fetchMock });
+    const account = await client.getFreshSynergiaAccount("child/login");
+
+    expect(account).toMatchObject({
+      accessToken: "fresh-secret",
+      login: "child-login",
+      scopes: ["Messages"],
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://portal.librus.pl/api/v3/SynergiaAccounts/fresh/child%2Flogin",
+      expect.objectContaining({
+        method: "GET",
+        headers: { accept: "application/json" },
+      }),
+    );
+  });
+
+  it("fails when a fresh Synergia account response is malformed", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: 10,
+          login: 42,
+          accessToken: "fresh-secret",
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      ),
+    );
+    const client = new PortalClient({ fetch: fetchMock });
+
+    await expect(
+      client.getFreshSynergiaAccount("child-login"),
+    ).rejects.toMatchObject({
+      code: "RESPONSE_VALIDATION_FAILED",
+      details: {
+        endpoint:
+          "https://portal.librus.pl/api/v3/SynergiaAccounts/fresh/child-login",
+      },
+    });
+  });
+
+  it("raises API errors for failed fresh Synergia account requests", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ message: "denied" }), {
+        status: 403,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const client = new PortalClient({ fetch: fetchMock });
+
+    await expect(
+      client.getFreshSynergiaAccount("child-login"),
+    ).rejects.toMatchObject({
+      code: "API_REQUEST_FAILED",
+      message: "Portal API request failed",
+      details: {
+        endpoint:
+          "https://portal.librus.pl/api/v3/SynergiaAccounts/fresh/child-login",
+        status: 403,
+      },
+    });
+  });
+
   it("maps 401 verification failures to authentication errors", async () => {
     const fetchMock = createLoginFetchMock(
       new Response("", {

--- a/test/synergia-messages.test.ts
+++ b/test/synergia-messages.test.ts
@@ -218,6 +218,70 @@ describe("SynergiaApiClient message methods", () => {
     },
   );
 
+  it("delegates message reads to an injected message backend", async () => {
+    const messageBackend = {
+      getMessage: vi.fn().mockResolvedValue({
+        Message: { Id: "message-1" },
+        Resources: {},
+        Url: "https://wiadomosci.librus.pl/api/inbox/messages/message-1",
+      }),
+      getUnreadMessages: vi.fn().mockResolvedValue({
+        Resources: {},
+        UnreadMessages: 2,
+        Url: "https://wiadomosci.librus.pl/api/inbox/unreadMessagesCount",
+      }),
+      listMessages: vi.fn().mockResolvedValue({
+        Messages: [{ Id: "message-1" }],
+        Resources: {},
+        Url: "https://wiadomosci.librus.pl/api/inbox/messages",
+      }),
+    };
+    const fetchMock = vi.fn<typeof fetch>();
+    const client = new SynergiaApiClient("token", {
+      fetch: fetchMock,
+      messageBackend,
+    });
+
+    await expect(client.listMessages({ limit: 10 })).resolves.toMatchObject({
+      Messages: [{ Id: "message-1" }],
+    });
+    await expect(client.getMessage("message-1")).resolves.toMatchObject({
+      Message: { Id: "message-1" },
+    });
+    await expect(client.getUnreadMessages()).resolves.toMatchObject({
+      UnreadMessages: 2,
+    });
+    expect(messageBackend.listMessages).toHaveBeenCalledWith({ limit: 10 });
+    expect(messageBackend.getMessage).toHaveBeenCalledWith("message-1");
+    expect(messageBackend.getUnreadMessages).toHaveBeenCalledTimes(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps receiver group reads on API 3.0 when a message backend is injected", async () => {
+    const messageBackend = {
+      getMessage: vi.fn(),
+      getUnreadMessages: vi.fn(),
+      listMessages: vi.fn(),
+    };
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValueOnce(
+      jsonResponse(
+        envelope("/Messages/ReceiversGroup", {
+          ReceiversGroup: [],
+        }),
+      ),
+    );
+    const client = new SynergiaApiClient("token", {
+      fetch: fetchMock,
+      messageBackend,
+    });
+
+    await expect(client.listMessageReceiverGroups()).resolves.toMatchObject({
+      ReceiversGroup: [],
+    });
+    expectJsonGetRequest(fetchMock, `${apiBaseUrl}/Messages/ReceiversGroup`);
+    expect(messageBackend.listMessages).not.toHaveBeenCalled();
+  });
+
   it("downloads message attachments as binary results", async () => {
     const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
       new Response(new Uint8Array([1, 2, 3]), {

--- a/test/wiadomosci-messages-client.test.ts
+++ b/test/wiadomosci-messages-client.test.ts
@@ -1,0 +1,272 @@
+import { Buffer } from "node:buffer";
+
+import { describe, expect, it, vi } from "vitest";
+
+import type { ChildAccount } from "../src/sdk/index.js";
+import { PortalClient } from "../src/sdk/portal/PortalClient.js";
+import { WiadomosciMessagesClient } from "../src/sdk/wiadomosci/WiadomosciMessagesClient.js";
+
+const child: ChildAccount = {
+  accessToken: "stale-child-token",
+  accountIdentifier: "child-101",
+  group: "parent",
+  id: 101,
+  login: "child-login",
+  state: "active",
+  studentName: "Child Name",
+};
+
+function createPortalClientStub(): {
+  ensurePortalLogin: ReturnType<typeof vi.fn>;
+  getFreshSynergiaAccount: ReturnType<typeof vi.fn>;
+  portalClient: PortalClient;
+} {
+  const ensurePortalLogin = vi.fn().mockResolvedValue(undefined);
+  const getFreshSynergiaAccount = vi.fn().mockResolvedValue({
+    ...child,
+    accessToken: "fresh-child-token",
+  });
+
+  return {
+    ensurePortalLogin,
+    getFreshSynergiaAccount,
+    portalClient: {
+      getFreshSynergiaAccount,
+    } as unknown as PortalClient,
+  };
+}
+
+function responseJson(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function responseText(
+  body = "",
+  status = 200,
+  headers: HeadersInit = {},
+): Response {
+  return new Response(body, {
+    status,
+    headers,
+  });
+}
+
+function requestUrls(fetchMock: {
+  mock: { calls: Parameters<typeof fetch>[] };
+}): string[] {
+  return fetchMock.mock.calls.map(([input]) =>
+    typeof input === "string"
+      ? input
+      : input instanceof URL
+        ? input.toString()
+        : input.url,
+  );
+}
+
+describe("WiadomosciMessagesClient", () => {
+  it("authenticates and normalizes inbox messages", async () => {
+    const { ensurePortalLogin, getFreshSynergiaAccount, portalClient } =
+      createPortalClientStub();
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(responseJson({ Token: "auto-login-token" }))
+      .mockResolvedValueOnce(responseText())
+      .mockResolvedValueOnce(responseText())
+      .mockResolvedValueOnce(
+        responseJson({
+          data: [
+            {
+              content: "Hello<br>World",
+              messageId: 151,
+              readDate: "2026-03-31 16:28:31",
+              sendDate: "2026-03-31 16:28:30",
+              senderId: 22,
+              senderName: "Teacher Name",
+              topic: "Topic",
+            },
+          ],
+          total: 1,
+        }),
+      );
+    const client = new WiadomosciMessagesClient(child, {
+      ensurePortalLogin,
+      fetch: fetchMock,
+      portalClient,
+    });
+    const payload = await client.listMessages({ limit: 10, page: 2 });
+
+    expect(ensurePortalLogin).toHaveBeenCalledTimes(1);
+    expect(getFreshSynergiaAccount).toHaveBeenCalledWith("child-login");
+    expect(requestUrls(fetchMock)).toEqual([
+      "https://api.librus.pl/2.0/AutoLoginToken",
+      "https://synergia.librus.pl/loguj/token/auto-login-token/przenies/uczen/widok/centrum_powiadomien",
+      "https://synergia.librus.pl/wiadomosci3",
+      "https://wiadomosci.librus.pl/api/inbox/messages?page=2&limit=10",
+    ]);
+    expect(payload.Url).toBe(
+      "https://wiadomosci.librus.pl/api/inbox/messages?page=2&limit=10",
+    );
+    expect(payload.Messages[0]).toMatchObject({
+      Body: "Hello<br>World",
+      Id: 151,
+      Sender: {
+        Id: 22,
+        Url: "https://wiadomosci.librus.pl/api/users/22",
+      },
+      Subject: "Topic",
+      content: "Hello<br>World",
+      senderName: "Teacher Name",
+    });
+    expect(typeof payload.Messages[0]?.SendDate).toBe("number");
+    expect(payload.Resources).toEqual({});
+  });
+
+  it("normalizes message detail and unread count responses", async () => {
+    const { portalClient } = createPortalClientStub();
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(responseJson({ Token: "auto-login-token" }))
+      .mockResolvedValueOnce(responseText())
+      .mockResolvedValueOnce(responseText())
+      .mockResolvedValueOnce(
+        responseJson({
+          data: {
+            Message: Buffer.from(
+              "<Message><Content><![CDATA[Detailed body]]></Content></Message>",
+            ).toString("base64"),
+            messageId: "message-7",
+            receiver: { id: 18 },
+            sendDate: "2026-03-31 16:28:30",
+            topic: "Detail topic",
+          },
+        }),
+      )
+      .mockResolvedValueOnce(responseJson({ data: "4" }));
+    const client = new WiadomosciMessagesClient(child, {
+      fetch: fetchMock,
+      portalClient,
+    });
+    const message = await client.getMessage("message-7");
+    const unread = await client.getUnreadMessages();
+
+    expect(requestUrls(fetchMock)).toEqual([
+      "https://api.librus.pl/2.0/AutoLoginToken",
+      "https://synergia.librus.pl/loguj/token/auto-login-token/przenies/uczen/widok/centrum_powiadomien",
+      "https://synergia.librus.pl/wiadomosci3",
+      "https://wiadomosci.librus.pl/api/inbox/messages/message-7",
+      "https://wiadomosci.librus.pl/api/inbox/unreadMessagesCount",
+    ]);
+    expect(message.Message).toMatchObject({
+      Body: "Detailed body",
+      Id: "message-7",
+      Receiver: {
+        Id: 18,
+        Url: "https://wiadomosci.librus.pl/api/users/18",
+      },
+      Subject: "Detail topic",
+    });
+    expect(unread.UnreadMessages).toBe(4);
+  });
+
+  it("reauthenticates once after an unauthorized wiadomosci response", async () => {
+    const { ensurePortalLogin, getFreshSynergiaAccount, portalClient } =
+      createPortalClientStub();
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(responseJson({ Token: "first-token" }))
+      .mockResolvedValueOnce(responseText())
+      .mockResolvedValueOnce(responseText())
+      .mockResolvedValueOnce(responseJson({}, 401))
+      .mockResolvedValueOnce(responseJson({ Token: "second-token" }))
+      .mockResolvedValueOnce(responseText())
+      .mockResolvedValueOnce(responseText())
+      .mockResolvedValueOnce(responseJson({ data: [], total: 0 }));
+    const client = new WiadomosciMessagesClient(child, {
+      ensurePortalLogin,
+      fetch: fetchMock,
+      portalClient,
+    });
+    const payload = await client.listMessages();
+
+    expect(payload.Messages).toEqual([]);
+    expect(ensurePortalLogin).toHaveBeenCalledTimes(2);
+    expect(getFreshSynergiaAccount).toHaveBeenCalledTimes(2);
+    expect(requestUrls(fetchMock)).toEqual([
+      "https://api.librus.pl/2.0/AutoLoginToken",
+      "https://synergia.librus.pl/loguj/token/first-token/przenies/uczen/widok/centrum_powiadomien",
+      "https://synergia.librus.pl/wiadomosci3",
+      "https://wiadomosci.librus.pl/api/inbox/messages?page=1&limit=300",
+      "https://api.librus.pl/2.0/AutoLoginToken",
+      "https://synergia.librus.pl/loguj/token/second-token/przenies/uczen/widok/centrum_powiadomien",
+      "https://synergia.librus.pl/wiadomosci3",
+      "https://wiadomosci.librus.pl/api/inbox/messages?page=1&limit=300",
+    ]);
+  });
+
+  it("keeps tokens out of authentication errors", async () => {
+    const { portalClient } = createPortalClientStub();
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      responseJson(
+        {
+          token: "fresh-child-token",
+          message: "auto-login-token denied",
+        },
+        403,
+      ),
+    );
+    const client = new WiadomosciMessagesClient(child, {
+      fetch: fetchMock,
+      portalClient,
+    });
+
+    try {
+      await client.listMessages();
+      throw new Error("Expected listMessages to fail");
+    } catch (error) {
+      const serialized = JSON.stringify(error);
+
+      expect(error).toMatchObject({
+        code: "API_REQUEST_FAILED",
+        message: "Wiadomosci authentication failed",
+        details: {
+          endpoint: "https://api.librus.pl/2.0/AutoLoginToken",
+          status: 403,
+        },
+      });
+      expect(serialized).not.toContain("fresh-child-token");
+      expect(serialized).not.toContain("auto-login-token");
+    }
+  });
+
+  it("redacts the one-time Synergia login token from login failures", async () => {
+    const { portalClient } = createPortalClientStub();
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(responseJson({ Token: "one-time-login-token" }))
+      .mockResolvedValueOnce(responseText("denied", 403));
+    const client = new WiadomosciMessagesClient(child, {
+      fetch: fetchMock,
+      portalClient,
+    });
+
+    try {
+      await client.listMessages();
+      throw new Error("Expected listMessages to fail");
+    } catch (error) {
+      const serialized = JSON.stringify(error);
+
+      expect(error).toMatchObject({
+        code: "API_REQUEST_FAILED",
+        details: {
+          endpoint:
+            "https://synergia.librus.pl/loguj/token/REDACTED/przenies/uczen/widok/centrum_powiadomien",
+          status: 403,
+        },
+      });
+      expect(serialized).not.toContain("one-time-login-token");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds a portal-authenticated `wiadomosci.librus.pl` message backend and wires session-created SDK/CLI message reads to prefer it for inbox list, detail, and unread count.

## What changed

- Added `WiadomosciMessagesClient` with the verified auth chain: portal fresh Synergia account -> API 2.0 `AutoLoginToken` -> Synergia token login -> `/wiadomosci3` -> `wiadomosci.librus.pl/api`.
- Added `PortalClient.getFreshSynergiaAccount(login)`.
- Let `SynergiaApiClient` delegate message reads to an injected backend while keeping direct token-only construction on API 3.0 by default.
- Updated session wiring, docs, unit tests, and live integration assertions for wiadomosci URLs.

## Validation

- `npm run build`
- `npm test`
- `npm run test:integration:sdk`
- Targeted live CLI checks for `messages list`, `messages unread`, and `messages get` on both configured children

Note: the full CLI integration matrix passed once earlier, but later reruns hit live `portal.librus.pl` login timeouts in isolated subprocesses. The affected message command passed when rerun directly.
