### PR TITLE
[codex] release 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-05-15
+
 ### Added
 
 - Session-created SDK clients and CLI message read commands now use the

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.3",
   "info": {
     "title": "Librus Synergia API (SDK-supported subset)",
-    "version": "0.5.0",
+    "version": "0.6.0",
     "description": "Best-effort OpenAPI document generated from the SDK's supported child-scoped Synergia GET surface. Authentication starts on portal.librus.pl; this document covers the subsequent bearer-token calls against api.librus.pl/3.0."
   },
   "servers": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "librus-sdk",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "librus-sdk",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@valibot/to-json-schema": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librus-sdk",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "TypeScript SDK and CLI for the Librus family portal flow.",
   "author": "Andrey Koltsov",
   "repository": {


### PR DESCRIPTION
## Summary

Prepares the `0.6.0` minor release after the wiadomosci message backend merge.

## What changed

- Bumped `package.json`, `package-lock.json`, and generated `openapi.json` to `0.6.0`.
- Moved the wiadomosci message backend changelog note from `Unreleased` into `0.6.0` dated `2026-05-15`.

## Validation

- `npm run validate`
- `node ./scripts/extract-release-notes.mjs 0.6.0`
