### PR TITLE
[codex] restore explicit message backend selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- `LibrusSession.forChildWiadomosci()` and CLI `messages wiadomosci-list`,
+  `messages wiadomosci-get`, and `messages wiadomosci-unread` now expose the
+  `wiadomosci.librus.pl` message backend explicitly.
+- CLI `messages list`, `messages get`, and `messages unread` now support
+  `--backend <api3|wiadomosci>`.
+
+### Fixed
+
+- `messages list`, `messages get`, `messages unread`, and
+  `LibrusSession.forChild()` now use API 3.0 by default again after the
+  `0.6.0` regression.
+
 ## [0.6.0] - 2026-05-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Current high-level methods on `LibrusSession`:
 - `listChildren()`
 - `resolveChild(selector)`
 - `forChild(selectorOrChild)`
+- `forChildWiadomosci(selectorOrChild)`
 - `forChildBff(selectorOrChild)`
 
 Current methods on `PortalClient`:
@@ -160,12 +161,14 @@ Attachment-style methods such as `getHomeworkAssignmentAttachment(id)`,
 `SynergiaBinaryResult` with `{ data, contentType, contentDisposition }`.
 
 When a `SynergiaApiClient` is created through `LibrusSession.forChild()`,
-message reads use the portal-authenticated `https://wiadomosci.librus.pl/api`
-inbox backend by default for `listMessages()`, `getMessage(id)`, and
-`getUnreadMessages()`. Other child-scoped reads, message receiver groups, and
-message attachment downloads continue to use `https://api.librus.pl/3.0`.
-Direct `new SynergiaApiClient(token)` construction keeps using API 3.0 for all
-methods unless a custom message backend is supplied.
+message reads use the standard `https://api.librus.pl/3.0` backend by default.
+Use `LibrusSession.forChildWiadomosci()` to opt in to the
+portal-authenticated `https://wiadomosci.librus.pl/api` inbox backend for
+`listMessages()`, `getMessage(id)`, and `getUnreadMessages()`. Other
+child-scoped reads, message receiver groups, and message attachment downloads
+continue to use `https://api.librus.pl/3.0`. Direct
+`new SynergiaApiClient(token)` construction keeps using API 3.0 for all methods
+unless a custom message backend is supplied.
 
 `BffApiClient` currently exposes the research-oriented `listMessages()` method
 for `GET https://testbff.librus.pl/v1/Messages`. It uses the selected child's
@@ -248,22 +251,22 @@ Every leaf command supports `--format <text|json>`. Child-scoped commands use
 `--child <id-or-login>` to select the linked child account by numeric id or by
 login.
 
-| Family           | Subcommands                                                                                                 | Extra selectors and flags                                                                                                          |
-| ---------------- | ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `children`       | `list`                                                                                                      | No child selector.                                                                                                                 |
-| `me`             | root command                                                                                                | `--child`.                                                                                                                         |
-| `grades`         | `list`                                                                                                      | `--child`.                                                                                                                         |
-| `attendance`     | `list`                                                                                                      | `--child`.                                                                                                                         |
-| `homework`       | `list`                                                                                                      | `--child`.                                                                                                                         |
-| `messages`       | `list`, `bff-list`, `get`, `unread`                                                                         | `list` supports `--after-id <id>`; `bff-list` reads the experimental BFF inbox payload; `get` requires `--id <id>`.                |
-| `timetable`      | `week`, `day`, `entry`                                                                                      | `week` requires `--week-start <YYYY-MM-DD>`; `day` requires `--day <YYYY-MM-DD>`; `entry` requires `--id <id>`.                    |
-| `announcements`  | `list`, `get`                                                                                               | `get` requires `--id <id>`.                                                                                                        |
-| `notes`          | `list`, `get`                                                                                               | `get` requires `--id <id>`.                                                                                                        |
-| `lessons`        | `list`, `get`, `planned-list`, `planned-get`, `planned-attachment`, `realizations-list`, `realizations-get` | `get`, `planned-get`, and `realizations-get` require `--id <id>`; `planned-attachment` requires `--id <id>` and `--output <path>`. |
-| `lucky-number`   | `get`                                                                                                       | Optional `--for-day <YYYY-MM-DD>`.                                                                                                 |
-| `notifications`  | `center`, `push-configurations`                                                                             | `--child`.                                                                                                                         |
-| `justifications` | `list`, `get`, `conferences`, `system-data`                                                                 | `list` supports `--date-from <YYYY-MM-DD>`; `get` requires `--id <id>`.                                                            |
-| `auth`           | `photos`, `photo`, `user-info`, `token-info`, `classroom`                                                   | `photo` requires `--id <id>` and `--output <path>`; `user-info` and `classroom` require `--id <id>`.                               |
+| Family           | Subcommands                                                                                                 | Extra selectors and flags                                                                                                                                                                                                                    |
+| ---------------- | ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `children`       | `list`                                                                                                      | No child selector.                                                                                                                                                                                                                           |
+| `me`             | root command                                                                                                | `--child`.                                                                                                                                                                                                                                   |
+| `grades`         | `list`                                                                                                      | `--child`.                                                                                                                                                                                                                                   |
+| `attendance`     | `list`                                                                                                      | `--child`.                                                                                                                                                                                                                                   |
+| `homework`       | `list`                                                                                                      | `--child`.                                                                                                                                                                                                                                   |
+| `messages`       | `list`, `bff-list`, `get`, `unread`, `wiadomosci-list`, `wiadomosci-get`, `wiadomosci-unread`               | `list`, `get`, and `unread` support `--backend <api3\|wiadomosci>` and default to `api3`; `wiadomosci-list` supports `--after-id <id>`; `bff-list` reads the experimental BFF inbox payload; `get` and `wiadomosci-get` require `--id <id>`. |
+| `timetable`      | `week`, `day`, `entry`                                                                                      | `week` requires `--week-start <YYYY-MM-DD>`; `day` requires `--day <YYYY-MM-DD>`; `entry` requires `--id <id>`.                                                                                                                              |
+| `announcements`  | `list`, `get`                                                                                               | `get` requires `--id <id>`.                                                                                                                                                                                                                  |
+| `notes`          | `list`, `get`                                                                                               | `get` requires `--id <id>`.                                                                                                                                                                                                                  |
+| `lessons`        | `list`, `get`, `planned-list`, `planned-get`, `planned-attachment`, `realizations-list`, `realizations-get` | `get`, `planned-get`, and `realizations-get` require `--id <id>`; `planned-attachment` requires `--id <id>` and `--output <path>`.                                                                                                           |
+| `lucky-number`   | `get`                                                                                                       | Optional `--for-day <YYYY-MM-DD>`.                                                                                                                                                                                                           |
+| `notifications`  | `center`, `push-configurations`                                                                             | `--child`.                                                                                                                                                                                                                                   |
+| `justifications` | `list`, `get`, `conferences`, `system-data`                                                                 | `list` supports `--date-from <YYYY-MM-DD>`; `get` requires `--id <id>`.                                                                                                                                                                      |
+| `auth`           | `photos`, `photo`, `user-info`, `token-info`, `classroom`                                                   | `photo` requires `--id <id>` and `--output <path>`; `user-info` and `classroom` require `--id <id>`.                                                                                                                                         |
 
 ### CLI Output Contract
 
@@ -329,10 +332,11 @@ Current codes emitted by the SDK and CLI:
 ### Troubleshooting
 
 Direct API 3.0 `messages` reads can fail with HTTP `403` even when other
-child-scoped endpoints such as `grades list` still work. Session-created SDK
-clients and CLI `messages list`, `messages get`, and `messages unread` use the
-portal-authenticated `wiadomosci.librus.pl` inbox backend by default to avoid
-that mobile-addons gate.
+child-scoped endpoints such as `grades list` still work. CLI
+`messages list`, `messages get`, and `messages unread` use API 3.0 by default.
+Pass `--backend wiadomosci` or use `messages wiadomosci-list`,
+`messages wiadomosci-get`, and `messages wiadomosci-unread` to read through the
+portal-authenticated `wiadomosci.librus.pl` inbox backend.
 
 When a `/Messages` request returns `API_REQUEST_FAILED` with `status: 403`, the
 SDK and CLI now add diagnostics under `error.details`:

--- a/src/cli/commands/messages.ts
+++ b/src/cli/commands/messages.ts
@@ -1,4 +1,6 @@
-import { Command } from "commander";
+import { Command, InvalidArgumentError } from "commander";
+
+import type { ChildAccount, LibrusSession } from "../../sdk/index.js";
 
 import type { CliContext } from "./common.js";
 import {
@@ -7,6 +9,12 @@ import {
   type CliFormatOptions,
   writeChildScopedOutput,
 } from "./common.js";
+
+type MessageBackendName = "api3" | "wiadomosci";
+
+interface MessageBackendOptions extends CliFormatOptions {
+  backend: MessageBackendName;
+}
 
 export function createMessagesCommand(context: CliContext): Command {
   const messages = configureCommand(
@@ -37,14 +45,46 @@ export function createMessagesCommand(context: CliContext): Command {
     ),
     context,
   );
+  const wiadomosciList = configureCommand(
+    addFormatOption(
+      new Command("wiadomosci-list").description(
+        "List messages through wiadomosci.librus.pl",
+      ),
+    ),
+    context,
+  );
+  const wiadomosciGet = configureCommand(
+    addFormatOption(
+      new Command("wiadomosci-get").description(
+        "Get a message through wiadomosci.librus.pl",
+      ),
+    ),
+    context,
+  );
+  const wiadomosciUnread = configureCommand(
+    addFormatOption(
+      new Command("wiadomosci-unread").description(
+        "List unread messages through wiadomosci.librus.pl",
+      ),
+    ),
+    context,
+  );
 
   list.requiredOption("--child <id-or-login>", "Child account id or login");
   list.option("--after-id <id>", "List messages after the given message id");
+  list.option(
+    "--backend <backend>",
+    "Message backend: api3 or wiadomosci",
+    parseMessageBackendName,
+    "api3",
+  );
   list.action(
-    async (options: CliFormatOptions & { afterId?: string; child: string }) => {
+    async (
+      options: MessageBackendOptions & { afterId?: string; child: string },
+    ) => {
       const session = context.createSession();
       const child = await session.resolveChild(options.child);
-      const client = await session.forChild(child);
+      const client = await createMessageClient(session, child, options.backend);
       const data = await client.listMessages(
         options.afterId ? { afterId: options.afterId } : {},
       );
@@ -65,11 +105,17 @@ export function createMessagesCommand(context: CliContext): Command {
 
   get.requiredOption("--child <id-or-login>", "Child account id or login");
   get.requiredOption("--id <id>", "Message id");
+  get.option(
+    "--backend <backend>",
+    "Message backend: api3 or wiadomosci",
+    parseMessageBackendName,
+    "api3",
+  );
   get.action(
-    async (options: CliFormatOptions & { child: string; id: string }) => {
+    async (options: MessageBackendOptions & { child: string; id: string }) => {
       const session = context.createSession();
       const child = await session.resolveChild(options.child);
-      const client = await session.forChild(child);
+      const client = await createMessageClient(session, child, options.backend);
       const data = await client.getMessage(options.id);
 
       writeChildScopedOutput(context, options.format, child, data);
@@ -77,19 +123,98 @@ export function createMessagesCommand(context: CliContext): Command {
   );
 
   unread.requiredOption("--child <id-or-login>", "Child account id or login");
-  unread.action(async (options: CliFormatOptions & { child: string }) => {
+  unread.option(
+    "--backend <backend>",
+    "Message backend: api3 or wiadomosci",
+    parseMessageBackendName,
+    "api3",
+  );
+  unread.action(async (options: MessageBackendOptions & { child: string }) => {
     const session = context.createSession();
     const child = await session.resolveChild(options.child);
-    const client = await session.forChild(child);
+    const client = await createMessageClient(session, child, options.backend);
     const data = await client.getUnreadMessages();
 
     writeChildScopedOutput(context, options.format, child, data);
   });
 
+  wiadomosciList.requiredOption(
+    "--child <id-or-login>",
+    "Child account id or login",
+  );
+  wiadomosciList.option(
+    "--after-id <id>",
+    "List messages after the given message id",
+  );
+  wiadomosciList.action(
+    async (options: CliFormatOptions & { afterId?: string; child: string }) => {
+      const session = context.createSession();
+      const child = await session.resolveChild(options.child);
+      const client = await session.forChildWiadomosci(child);
+      const data = await client.listMessages(
+        options.afterId ? { afterId: options.afterId } : {},
+      );
+
+      writeChildScopedOutput(context, options.format, child, data);
+    },
+  );
+
+  wiadomosciGet.requiredOption(
+    "--child <id-or-login>",
+    "Child account id or login",
+  );
+  wiadomosciGet.requiredOption("--id <id>", "Message id");
+  wiadomosciGet.action(
+    async (options: CliFormatOptions & { child: string; id: string }) => {
+      const session = context.createSession();
+      const child = await session.resolveChild(options.child);
+      const client = await session.forChildWiadomosci(child);
+      const data = await client.getMessage(options.id);
+
+      writeChildScopedOutput(context, options.format, child, data);
+    },
+  );
+
+  wiadomosciUnread.requiredOption(
+    "--child <id-or-login>",
+    "Child account id or login",
+  );
+  wiadomosciUnread.action(
+    async (options: CliFormatOptions & { child: string }) => {
+      const session = context.createSession();
+      const child = await session.resolveChild(options.child);
+      const client = await session.forChildWiadomosci(child);
+      const data = await client.getUnreadMessages();
+
+      writeChildScopedOutput(context, options.format, child, data);
+    },
+  );
+
   messages.addCommand(list);
   messages.addCommand(bffList);
   messages.addCommand(get);
   messages.addCommand(unread);
+  messages.addCommand(wiadomosciList);
+  messages.addCommand(wiadomosciGet);
+  messages.addCommand(wiadomosciUnread);
 
   return messages;
+}
+
+function parseMessageBackendName(value: string): MessageBackendName {
+  if (value === "api3" || value === "wiadomosci") {
+    return value;
+  }
+
+  throw new InvalidArgumentError('Expected "api3" or "wiadomosci".');
+}
+
+async function createMessageClient(
+  session: LibrusSession,
+  child: ChildAccount,
+  backend: MessageBackendName,
+): ReturnType<LibrusSession["forChild"]> {
+  return backend === "wiadomosci"
+    ? session.forChildWiadomosci(child)
+    : session.forChild(child);
 }

--- a/src/sdk/LibrusSession.ts
+++ b/src/sdk/LibrusSession.ts
@@ -221,13 +221,22 @@ export class LibrusSession {
       typeof selectorOrChild === "string"
         ? await this.resolveChild(selectorOrChild)
         : selectorOrChild;
-    const messageBackend =
-      this.synergiaClientOptions?.messageBackend ??
-      new WiadomosciMessagesClient(child, {
-        ...this.wiadomosciClientOptions,
-        ensurePortalLogin: () => this.login(),
-        portalClient: this.portalClient,
-      });
+
+    return new SynergiaApiClient(child.accessToken, this.synergiaClientOptions);
+  }
+
+  async forChildWiadomosci(
+    selectorOrChild: string | ChildAccount,
+  ): Promise<SynergiaApiClient> {
+    const child =
+      typeof selectorOrChild === "string"
+        ? await this.resolveChild(selectorOrChild)
+        : selectorOrChild;
+    const messageBackend = new WiadomosciMessagesClient(child, {
+      ...this.wiadomosciClientOptions,
+      ensurePortalLogin: () => this.login(),
+      portalClient: this.portalClient,
+    });
 
     return new SynergiaApiClient(child.accessToken, {
       ...this.synergiaClientOptions,

--- a/test/cli-high-value.test.ts
+++ b/test/cli-high-value.test.ts
@@ -50,6 +50,9 @@ function createCommandContext(
   const forChild = vi.fn().mockResolvedValue({
     [method]: apiMethod,
   });
+  const forChildWiadomosci = vi.fn().mockResolvedValue({
+    [method]: apiMethod,
+  });
   const forChildBff = vi.fn().mockResolvedValue({
     [method]: apiMethod,
   });
@@ -65,10 +68,12 @@ function createCommandContext(
         ({
           resolveChild,
           forChild,
+          forChildWiadomosci,
           forChildBff,
         }) as never,
     },
     forChild,
+    forChildWiadomosci,
     forChildBff,
     getOutput: () => ({ stderr, stdout }),
     resolveChild,
@@ -284,6 +289,42 @@ const usageFailureCases = [
     expectedMessage: "required option '--child <id-or-login>' not specified",
   },
   {
+    name: "messages list rejects invalid backend",
+    argv: [
+      "node",
+      "librus",
+      "messages",
+      "list",
+      "--child",
+      "child-login",
+      "--backend",
+      "old-api",
+    ],
+    expectedMessage: 'Expected "api3" or "wiadomosci".',
+  },
+  {
+    name: "messages wiadomosci-list requires child",
+    argv: ["node", "librus", "messages", "wiadomosci-list"],
+    expectedMessage: "required option '--child <id-or-login>' not specified",
+  },
+  {
+    name: "messages wiadomosci-get requires id",
+    argv: [
+      "node",
+      "librus",
+      "messages",
+      "wiadomosci-get",
+      "--child",
+      "child-login",
+    ],
+    expectedMessage: "required option '--id <id>' not specified",
+  },
+  {
+    name: "messages wiadomosci-unread requires child",
+    argv: ["node", "librus", "messages", "wiadomosci-unread"],
+    expectedMessage: "required option '--child <id-or-login>' not specified",
+  },
+  {
     name: "timetable week requires week start",
     argv: ["node", "librus", "timetable", "week", "--child", "child-login"],
     expectedMessage:
@@ -325,8 +366,15 @@ describe("runCli high-value commands", () => {
   it.each(successCases)(
     "writes success payloads for $name",
     async ({ argv, expectedArgs, method, response }) => {
-      const { apiMethod, child, context, forChild, getOutput, resolveChild } =
-        createCommandContext(method, response);
+      const {
+        apiMethod,
+        child,
+        context,
+        forChild,
+        forChildWiadomosci,
+        getOutput,
+        resolveChild,
+      } = createCommandContext(method, response);
 
       const exitCode = await runCli(withJsonFormat(argv), context);
       const output = parseJson<{ child: { login: string }; data: unknown }>(
@@ -337,6 +385,7 @@ describe("runCli high-value commands", () => {
       expect(getOutput().stderr).toBe("");
       expect(resolveChild).toHaveBeenCalledWith("child-login");
       expect(forChild).toHaveBeenCalledWith(child);
+      expect(forChildWiadomosci).not.toHaveBeenCalled();
       expect(apiMethod).toHaveBeenCalledWith(...expectedArgs);
       expect(output.child.login).toBe("child-login");
       expect(output.data).toEqual(response);
@@ -382,6 +431,7 @@ describe("runCli high-value commands", () => {
       context,
       forChild,
       forChildBff,
+      forChildWiadomosci,
       getOutput,
       resolveChild,
     } = createCommandContext("listMessages", response);
@@ -405,11 +455,138 @@ describe("runCli high-value commands", () => {
     expect(getOutput().stderr).toBe("");
     expect(resolveChild).toHaveBeenCalledWith("child-login");
     expect(forChild).not.toHaveBeenCalled();
+    expect(forChildWiadomosci).not.toHaveBeenCalled();
     expect(forChildBff).toHaveBeenCalledWith(child);
     expect(apiMethod).toHaveBeenCalledWith();
     expect(output.child.login).toBe("child-login");
     expect(output.data).toEqual(response);
   });
+
+  it.each([
+    {
+      name: "messages list --backend wiadomosci",
+      argv: [
+        "node",
+        "librus",
+        "messages",
+        "list",
+        "--child",
+        "child-login",
+        "--backend",
+        "wiadomosci",
+      ],
+      expectedArgs: [{}],
+      method: "listMessages",
+      response: {
+        Messages: [],
+        Resources: {},
+        Url: "https://wiadomosci.librus.pl/api/inbox/messages",
+      },
+    },
+    {
+      name: "messages wiadomosci-list with after-id",
+      argv: [
+        "node",
+        "librus",
+        "messages",
+        "wiadomosci-list",
+        "--child",
+        "child-login",
+        "--after-id",
+        "42",
+      ],
+      expectedArgs: [{ afterId: "42" }],
+      method: "listMessages",
+      response: {
+        Messages: [],
+        Resources: {},
+        Url: "https://wiadomosci.librus.pl/api/inbox/messages?afterId=42",
+      },
+    },
+    {
+      name: "messages wiadomosci-list",
+      argv: [
+        "node",
+        "librus",
+        "messages",
+        "wiadomosci-list",
+        "--child",
+        "child-login",
+      ],
+      expectedArgs: [{}],
+      method: "listMessages",
+      response: {
+        Messages: [],
+        Resources: {},
+        Url: "https://wiadomosci.librus.pl/api/inbox/messages",
+      },
+    },
+    {
+      name: "messages wiadomosci-get",
+      argv: [
+        "node",
+        "librus",
+        "messages",
+        "wiadomosci-get",
+        "--child",
+        "child-login",
+        "--id",
+        "17",
+      ],
+      expectedArgs: ["17"],
+      method: "getMessage",
+      response: {
+        Message: { Id: 17 },
+        Resources: {},
+        Url: "https://wiadomosci.librus.pl/api/inbox/messages/17",
+      },
+    },
+    {
+      name: "messages wiadomosci-unread",
+      argv: [
+        "node",
+        "librus",
+        "messages",
+        "wiadomosci-unread",
+        "--child",
+        "child-login",
+      ],
+      expectedArgs: [],
+      method: "getUnreadMessages",
+      response: {
+        UnreadMessages: 4,
+        Resources: {},
+        Url: "https://wiadomosci.librus.pl/api/inbox/unreadMessagesCount",
+      },
+    },
+  ])(
+    "writes success payloads for $name",
+    async ({ argv, expectedArgs, method, response }) => {
+      const {
+        apiMethod,
+        child,
+        context,
+        forChild,
+        forChildWiadomosci,
+        getOutput,
+        resolveChild,
+      } = createCommandContext(method, response);
+
+      const exitCode = await runCli(withJsonFormat(argv), context);
+      const output = parseJson<{ child: { login: string }; data: unknown }>(
+        getOutput().stdout,
+      );
+
+      expect(exitCode).toBe(0);
+      expect(getOutput().stderr).toBe("");
+      expect(resolveChild).toHaveBeenCalledWith("child-login");
+      expect(forChild).not.toHaveBeenCalled();
+      expect(forChildWiadomosci).toHaveBeenCalledWith(child);
+      expect(apiMethod).toHaveBeenCalledWith(...expectedArgs);
+      expect(output.child.login).toBe("child-login");
+      expect(output.data).toEqual(response);
+    },
+  );
 
   it("keeps new command failures secret-safe", async () => {
     let stderr = "";

--- a/test/integration/helpers/cli.mjs
+++ b/test/integration/helpers/cli.mjs
@@ -259,9 +259,15 @@ function summarizeSuccess(args, payload) {
 
   if (commandName === "messages") {
     const usesWiadomosci =
-      subcommandName === "list" ||
-      subcommandName === "get" ||
-      subcommandName === "unread";
+      subcommandName.startsWith("wiadomosci-") ||
+      args.includes("--backend=wiadomosci") ||
+      (args.includes("--backend") &&
+        args[args.indexOf("--backend") + 1] === "wiadomosci");
+    const usesApi3 =
+      (subcommandName === "list" ||
+        subcommandName === "get" ||
+        subcommandName === "unread") &&
+      !usesWiadomosci;
     const url = payload.data?.Url;
 
     if (
@@ -276,19 +282,31 @@ function summarizeSuccess(args, payload) {
       };
     }
 
+    if (
+      usesApi3 &&
+      (typeof url !== "string" || !url.startsWith("https://api.librus.pl/"))
+    ) {
+      return {
+        ok: false,
+        child: payload.child ? summarizeChild(payload.child) : null,
+        errorMessage: `Expected api.librus.pl message URL, got ${url}`,
+      };
+    }
+
     return {
       ok: true,
       child: payload.child ? summarizeChild(payload.child) : null,
       count:
         subcommandName === "bff-list"
           ? (payload.data?.inboxMessages?.length ?? 0)
-          : subcommandName === "unread"
+          : subcommandName === "unread" ||
+              subcommandName === "wiadomosci-unread"
             ? typeof payload.data?.UnreadMessages === "number"
               ? payload.data.UnreadMessages
               : 0
             : (payload.data?.Messages?.length ?? 0),
       keys:
-        subcommandName === "get"
+        subcommandName === "get" || subcommandName === "wiadomosci-get"
           ? Object.keys(payload.data?.Message ?? {})
           : [],
     };
@@ -435,6 +453,23 @@ function summarizeOrSkipCliStatus(result, status, reason) {
   return summarizeCliResult(result);
 }
 
+function isDefaultApi3MessageCommand(args) {
+  if (args[0] !== "messages") {
+    return false;
+  }
+
+  if (args[1] !== "list" && args[1] !== "get" && args[1] !== "unread") {
+    return false;
+  }
+
+  const backendIndex = args.indexOf("--backend");
+
+  return (
+    !args.includes("--backend=wiadomosci") &&
+    (backendIndex === -1 || args[backendIndex + 1] !== "wiadomosci")
+  );
+}
+
 export function runCliCommand(args, env = process.env) {
   assertBuiltCli();
   const commandArgs = [...args, "--format", "json"];
@@ -519,8 +554,18 @@ export function runCliMatrix(env = process.env) {
         ["attendance", "list", "--child", String(child.id)],
         ["homework", "list", "--child", String(child.id)],
         ["messages", "list", "--child", String(child.id)],
+        [
+          "messages",
+          "list",
+          "--child",
+          String(child.id),
+          "--backend",
+          "wiadomosci",
+        ],
+        ["messages", "wiadomosci-list", "--child", String(child.id)],
         ["messages", "bff-list", "--child", String(child.id)],
         ["messages", "unread", "--child", String(child.id)],
+        ["messages", "wiadomosci-unread", "--child", String(child.id)],
         ["timetable", "day", "--child", String(child.id), "--day", currentDay],
         [
           "timetable",
@@ -548,7 +593,15 @@ export function runCliMatrix(env = process.env) {
         const result = runCliCommand(args, env);
 
         childCommandResults.set(args.join("\u0000"), result);
-        targetResults.push(summarizeCliResult(result));
+        targetResults.push(
+          isDefaultApi3MessageCommand(args)
+            ? summarizeOrSkipCliStatus(
+                result,
+                403,
+                "API 3.0 messages returned 403 for this child account.",
+              )
+            : summarizeCliResult(result),
+        );
       }
 
       const messagesList = childCommandResults.get(
@@ -562,7 +615,7 @@ export function runCliMatrix(env = process.env) {
               ["messages", "get", "--child", String(child.id), "--id", "<id>"],
               "No message id found in the live messages payload.",
             )
-          : summarizeCliResult(
+          : summarizeOrSkipCliStatus(
               runCliCommand(
                 [
                   "messages",
@@ -571,6 +624,45 @@ export function runCliMatrix(env = process.env) {
                   String(child.id),
                   "--id",
                   String(messageId),
+                ],
+                env,
+              ),
+              403,
+              "API 3.0 message detail returned 403 for this child account.",
+            ),
+      );
+
+      const wiadomosciMessagesList = childCommandResults.get(
+        ["messages", "wiadomosci-list", "--child", String(child.id)].join(
+          "\u0000",
+        ),
+      );
+      const wiadomosciMessageId = findEntityId(
+        wiadomosciMessagesList.payload?.data?.Messages,
+      );
+
+      targetResults.push(
+        wiadomosciMessageId === null
+          ? skippedCliResult(
+              [
+                "messages",
+                "wiadomosci-get",
+                "--child",
+                String(child.id),
+                "--id",
+                "<id>",
+              ],
+              "No message id found in the live wiadomosci messages payload.",
+            )
+          : summarizeCliResult(
+              runCliCommand(
+                [
+                  "messages",
+                  "wiadomosci-get",
+                  "--child",
+                  String(child.id),
+                  "--id",
+                  String(wiadomosciMessageId),
                 ],
                 env,
               ),

--- a/test/integration/helpers/sdk.mjs
+++ b/test/integration/helpers/sdk.mjs
@@ -77,6 +77,25 @@ function assertWiadomosciUrl(payload) {
   );
 }
 
+function assertApi3Url(payload) {
+  assert.equal(
+    typeof payload.Url === "string" &&
+      payload.Url.startsWith("https://api.librus.pl/"),
+    true,
+    `Expected api.librus.pl URL, got ${payload.Url}`,
+  );
+}
+
+function summarizeApi3ArrayResponse(payload, key) {
+  assertApi3Url(payload);
+  return summarizeArrayResponse(payload, key);
+}
+
+function summarizeApi3CountResponse(payload, key) {
+  assertApi3Url(payload);
+  return summarizeCountResponse(payload, key);
+}
+
 function summarizeWiadomosciArrayResponse(payload, key) {
   assertWiadomosciUrl(payload);
   return summarizeArrayResponse(payload, key);
@@ -197,22 +216,6 @@ function arrayCheck(name, load, key) {
     name,
     load,
     summarize: (payload) => summarizeArrayResponse(payload, key),
-  };
-}
-
-function wiadomosciArrayCheck(name, load, key) {
-  return {
-    name,
-    load,
-    summarize: (payload) => summarizeWiadomosciArrayResponse(payload, key),
-  };
-}
-
-function wiadomosciCountCheck(name, load, key) {
-  return {
-    name,
-    load,
-    summarize: (payload) => summarizeWiadomosciCountResponse(payload, key),
   };
 }
 
@@ -756,9 +759,17 @@ async function runTimetableEntryCheck(api) {
   }
 }
 
-async function runMessageDetailCheck(api) {
+async function runMessageDetailCheck(
+  api,
+  { allowForbidden = false, expectWiadomosciUrl = false } = {},
+) {
   try {
     const payload = await api.listMessages();
+    if (expectWiadomosciUrl) {
+      assertWiadomosciUrl(payload);
+    } else {
+      assertApi3Url(payload);
+    }
     const messageId = findEntityId(payload.Messages);
 
     if (messageId === null) {
@@ -770,7 +781,11 @@ async function runMessageDetailCheck(api) {
     }
 
     const message = await api.getMessage(messageId);
-    assertWiadomosciUrl(message);
+    if (expectWiadomosciUrl) {
+      assertWiadomosciUrl(message);
+    } else {
+      assertApi3Url(message);
+    }
 
     return {
       ok: true,
@@ -778,6 +793,74 @@ async function runMessageDetailCheck(api) {
       keys: Object.keys(message.Message ?? {}),
     };
   } catch (error) {
+    if (allowForbidden && isApiStatus(error, 403)) {
+      return {
+        ok: true,
+        skipped: true,
+        reason: "API 3.0 messages returned 403 for this child account.",
+      };
+    }
+
+    return {
+      ok: false,
+      error: serializeError(error),
+    };
+  }
+}
+
+async function runWiadomosciMessagesCheck(api) {
+  return runCheck(
+    () => api.listMessages(),
+    (payload) => summarizeWiadomosciArrayResponse(payload, "Messages"),
+  );
+}
+
+async function runWiadomosciUnreadMessagesCheck(api) {
+  return runCheck(
+    () => api.getUnreadMessages(),
+    (payload) => summarizeWiadomosciCountResponse(payload, "UnreadMessages"),
+  );
+}
+
+async function runApi3MessagesCheck(api) {
+  try {
+    const payload = await api.listMessages();
+    return {
+      ok: true,
+      ...summarizeApi3ArrayResponse(payload, "Messages"),
+    };
+  } catch (error) {
+    if (isApiStatus(error, 403)) {
+      return {
+        ok: true,
+        skipped: true,
+        reason: "API 3.0 messages returned 403 for this child account.",
+      };
+    }
+
+    return {
+      ok: false,
+      error: serializeError(error),
+    };
+  }
+}
+
+async function runApi3UnreadMessagesCheck(api) {
+  try {
+    const payload = await api.getUnreadMessages();
+    return {
+      ok: true,
+      ...summarizeApi3CountResponse(payload, "UnreadMessages"),
+    };
+  } catch (error) {
+    if (isApiStatus(error, 403)) {
+      return {
+        ok: true,
+        skipped: true,
+        reason: "API 3.0 unread messages returned 403 for this child account.",
+      };
+    }
+
     return {
       ok: false,
       error: serializeError(error),
@@ -1103,12 +1186,6 @@ const sdkChecks = [
   keysCheck("systemData", (api) => api.getSystemData()),
   objectCheck("authPhotos", (api) => api.listAuthPhotos(), "data"),
   keysCheck("authTokenInfo", (api) => api.getAuthTokenInfo()),
-  wiadomosciArrayCheck("messages", (api) => api.listMessages(), "Messages"),
-  wiadomosciCountCheck(
-    "unreadMessages",
-    (api) => api.getUnreadMessages(),
-    "UnreadMessages",
-  ),
   arrayCheck(
     "messageReceiverGroups",
     (api) => api.listMessageReceiverGroups(),
@@ -1148,6 +1225,7 @@ export async function runSdkMatrix(env = process.env) {
 
   for (const child of targetChildren) {
     const api = await session.forChild(child);
+    const wiadomosciApi = await session.forChildWiadomosci(child);
     const checkEntries = await Promise.all(
       sdkChecks.map(async ({ name, load, summarize }) => {
         const check = await runCheck(() => load(api), summarize);
@@ -1165,7 +1243,17 @@ export async function runSdkMatrix(env = process.env) {
     const authPhotoDetail = await runAuthPhotoDetailCheck(api);
     const authUserInfo = await runAuthUserInfoCheck(api);
     const authClassroom = await runAuthClassroomCheck(api);
-    const messageDetail = await runMessageDetailCheck(api);
+    const messages = await runApi3MessagesCheck(api);
+    const unreadMessages = await runApi3UnreadMessagesCheck(api);
+    const messageDetail = await runMessageDetailCheck(api, {
+      allowForbidden: true,
+    });
+    const wiadomosciMessages = await runWiadomosciMessagesCheck(wiadomosciApi);
+    const wiadomosciUnreadMessages =
+      await runWiadomosciUnreadMessagesCheck(wiadomosciApi);
+    const wiadomosciMessageDetail = await runMessageDetailCheck(wiadomosciApi, {
+      expectWiadomosciUrl: true,
+    });
     const messageReceiverGroupDetail =
       await runMessageReceiverGroupDetailCheck(api);
     const schoolNoticeDetail = await runSchoolNoticeDetailCheck(api);
@@ -1188,7 +1276,12 @@ export async function runSdkMatrix(env = process.env) {
       ["authPhotoDetail", authPhotoDetail],
       ["authUserInfo", authUserInfo],
       ["authClassroom", authClassroom],
+      ["messages", messages],
+      ["unreadMessages", unreadMessages],
       ["messageDetail", messageDetail],
+      ["wiadomosciMessages", wiadomosciMessages],
+      ["wiadomosciUnreadMessages", wiadomosciUnreadMessages],
+      ["wiadomosciMessageDetail", wiadomosciMessageDetail],
       ["messageReceiverGroupDetail", messageReceiverGroupDetail],
       ["schoolNoticeDetail", schoolNoticeDetail],
       ["noteDetail", noteDetail],

--- a/test/librus-session.test.ts
+++ b/test/librus-session.test.ts
@@ -464,7 +464,60 @@ describe("LibrusSession.resolveChild", () => {
     expect(grades.Grades).toEqual([]);
   });
 
-  it("uses the wiadomosci backend for session-created message reads", async () => {
+  it("uses API 3.0 for session-created message reads by default", async () => {
+    const child = createChild({
+      accessToken: "child-access-token",
+    });
+    const { getFreshSynergiaAccount, portalClient } = createPortalClientStub({
+      accounts: [child],
+    });
+    const fetchMock = vi.fn<typeof fetch>(async (input, init) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+
+      expect(url).toBe(
+        "https://api.librus.pl/3.0/Messages?alternativeBody=true&changeNewLine=1&getAllTypes=1&page=1&limit=10",
+      );
+      expect(init?.headers).toMatchObject({
+        accept: "application/json",
+        authorization: "Bearer child-access-token",
+      });
+
+      return new Response(
+        JSON.stringify({
+          Messages: [{ Id: 1, Subject: "Hello" }],
+          Resources: {},
+          Url: "https://api.librus.pl/3.0/Messages",
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    });
+    const session = new LibrusSession({
+      credentials: { email: "parent@example.com", password: "secret" },
+      portalClient,
+      synergiaClientOptions: { fetch: fetchMock },
+      wiadomosciClientOptions: { fetch: vi.fn<typeof fetch>() },
+    });
+
+    const client = await session.forChild(child);
+    const messages = await client.listMessages({ limit: 10 });
+
+    expect(getFreshSynergiaAccount).not.toHaveBeenCalled();
+    expect(messages).toMatchObject({
+      Messages: [{ Id: 1, Subject: "Hello" }],
+      Resources: {},
+      Url: "https://api.librus.pl/3.0/Messages",
+    });
+  });
+
+  it("uses the wiadomosci backend for explicit wiadomosci child clients", async () => {
     const child = createChild({
       accessToken: "child-access-token",
     });
@@ -499,7 +552,7 @@ describe("LibrusSession.resolveChild", () => {
       wiadomosciClientOptions: { fetch: fetchMock },
     });
 
-    const client = await session.forChild(child);
+    const client = await session.forChildWiadomosci(child);
     const messages = await client.listMessages({ limit: 10 });
 
     expect(getFreshSynergiaAccount).toHaveBeenCalledWith("child-login");
@@ -507,6 +560,48 @@ describe("LibrusSession.resolveChild", () => {
       Messages: [{ Id: 1, Subject: "Hello" }],
       Resources: {},
       Url: "https://wiadomosci.librus.pl/api/inbox/messages?page=1&limit=10",
+    });
+  });
+
+  it("resolves child selectors for explicit wiadomosci child clients", async () => {
+    const child = createChild({
+      accessToken: "child-access-token",
+    });
+    const { getFreshSynergiaAccount, getSynergiaAccounts, portalClient } =
+      createPortalClientStub({
+        accounts: [child],
+      });
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ Token: "auto-login-token" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(new Response("", { status: 200 }))
+      .mockResolvedValueOnce(new Response("", { status: 200 }))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ data: 3 }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+    const session = new LibrusSession({
+      credentials: { email: "parent@example.com", password: "secret" },
+      portalClient,
+      wiadomosciClientOptions: { fetch: fetchMock },
+    });
+
+    const client = await session.forChildWiadomosci("child-login");
+    const unread = await client.getUnreadMessages();
+
+    expect(getSynergiaAccounts).toHaveBeenCalledTimes(1);
+    expect(getFreshSynergiaAccount).toHaveBeenCalledWith("child-login");
+    expect(unread).toMatchObject({
+      Resources: {},
+      UnreadMessages: 3,
+      Url: "https://wiadomosci.librus.pl/api/inbox/unreadMessagesCount",
     });
   });
 


### PR DESCRIPTION
## Summary

Restores API 3.0 as the default backend for existing message reads and makes the wiadomosci backend explicit.

## What changed

- `LibrusSession.forChild()` now returns a normal API 3.0-backed `SynergiaApiClient` again.
- Added `LibrusSession.forChildWiadomosci()` for opt-in wiadomosci message reads.
- Added CLI `--backend <api3|wiadomosci>` for `messages list/get/unread` plus `wiadomosci-list/get/unread` aliases.
- Updated unit and live integration checks to cover both default API and explicit wiadomosci paths.

## Validation

- `npm test`
- `npm run build`
- `npm run test:integration:sdk`
- `npm run test:integration:cli`
- `npm run lint`
- `npx prettier --check README.md CHANGELOG.md src/cli/commands/messages.ts test/cli-high-value.test.ts test/integration/helpers/cli.mjs test/integration/helpers/sdk.mjs test/librus-session.test.ts`
- `npm run test:coverage`
- `npm run pack:check`

Note: full `npm run validate` reaches the same tracked-code checks, but `format:check` also scans unrelated untracked `.tasks/*` files in this worktree and fails on those files.
