### PR TITLE
Handle HTML message body - wiadomosci

### DIFF
--- a/src/sdk/wiadomosci/WiadomosciMessagesClient.ts
+++ b/src/sdk/wiadomosci/WiadomosciMessagesClient.ts
@@ -350,7 +350,7 @@ function decodeMessageXml(value: string): string | null {
   }
 
   if (!decoded.includes("<Message")) {
-    return null;
+    return decoded;
   }
 
   const content = /<Content><!\[CDATA\[([\s\S]*?)\]\]><\/Content>/.exec(

--- a/src/sdk/wiadomosci/WiadomosciMessagesClient.ts
+++ b/src/sdk/wiadomosci/WiadomosciMessagesClient.ts
@@ -341,11 +341,9 @@ function normalizeMessageBody(raw: JsonObject): unknown {
 }
 
 function decodeMessageXml(value: string): string | null {
-  let decoded: string;
+  const decoded = decodeBase64Text(value);
 
-  try {
-    decoded = Buffer.from(value, "base64").toString("utf8");
-  } catch {
+  if (decoded === null) {
     return null;
   }
 
@@ -358,6 +356,25 @@ function decodeMessageXml(value: string): string | null {
   );
 
   return content?.[1] ?? decoded;
+}
+
+function decodeBase64Text(value: string): string | null {
+  const compactValue = value.replace(/\s+/g, "");
+
+  if (
+    compactValue.length === 0 ||
+    compactValue.length % 4 === 1 ||
+    !/^[A-Za-z0-9+/]*={0,2}$/.test(compactValue)
+  ) {
+    return null;
+  }
+
+  const decoded = Buffer.from(compactValue, "base64").toString("utf8");
+  const encoded = Buffer.from(decoded, "utf8").toString("base64");
+
+  return encoded.replace(/=+$/, "") === compactValue.replace(/=+$/, "")
+    ? decoded
+    : null;
 }
 
 function normalizeDate(value: unknown): unknown {

--- a/test/wiadomosci-messages-client.test.ts
+++ b/test/wiadomosci-messages-client.test.ts
@@ -171,6 +171,64 @@ describe("WiadomosciMessagesClient", () => {
     expect(unread.UnreadMessages).toBe(4);
   });
 
+  it("decodes base64 message bodies without an XML envelope", async () => {
+    const { portalClient } = createPortalClientStub();
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(responseJson({ Token: "auto-login-token" }))
+      .mockResolvedValueOnce(responseText())
+      .mockResolvedValueOnce(responseText())
+      .mockResolvedValueOnce(
+        responseJson({
+          data: {
+            Message: Buffer.from(
+              'Hello<br><a href="https://example.test">Link</a>',
+            ).toString("base64"),
+            messageId: "message-7",
+          },
+        }),
+      );
+    const client = new WiadomosciMessagesClient(child, {
+      fetch: fetchMock,
+      portalClient,
+    });
+
+    const message = await client.getMessage("message-7");
+
+    expect(message.Message).toMatchObject({
+      Body: 'Hello<br><a href="https://example.test">Link</a>',
+      Id: "message-7",
+    });
+  });
+
+  it("preserves plain non-base64 message bodies", async () => {
+    const { portalClient } = createPortalClientStub();
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(responseJson({ Token: "auto-login-token" }))
+      .mockResolvedValueOnce(responseText())
+      .mockResolvedValueOnce(responseText())
+      .mockResolvedValueOnce(
+        responseJson({
+          data: {
+            Message: "Hello<br>World",
+            messageId: "message-7",
+          },
+        }),
+      );
+    const client = new WiadomosciMessagesClient(child, {
+      fetch: fetchMock,
+      portalClient,
+    });
+
+    const message = await client.getMessage("message-7");
+
+    expect(message.Message).toMatchObject({
+      Body: "Hello<br>World",
+      Id: "message-7",
+    });
+  });
+
   it("reauthenticates once after an unauthorized wiadomosci response", async () => {
     const { ensurePortalLogin, getFreshSynergiaAccount, portalClient } =
       createPortalClientStub();


### PR DESCRIPTION
Messages are not always in XML `<Message><Content><![CDATA[` format. Sometimes it is just text without or with some simple HTML tags, `<br>`, `<a>`. Those message bodies were seen as base64 in result of `client.getMessage(Id)`. Returning $decoded here gives raw HTML tags in "Body", but now they may be stripped or not later.