### PR TITLE
release 0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.6.2] - 2026-05-17
+
+### Fixed
+
+- `WiadomosciMessagesClient.getMessage()` now decodes base64-encoded
+  `wiadomosci.librus.pl` message bodies even when Librus returns plain HTML
+  instead of the legacy XML `<Message><Content><![CDATA[...]]></Content>`
+  envelope.
+
 ## [0.6.1] - 2026-05-15
 
 ### Added

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.3",
   "info": {
     "title": "Librus Synergia API (SDK-supported subset)",
-    "version": "0.6.1",
+    "version": "0.6.2",
     "description": "Best-effort OpenAPI document generated from the SDK's supported child-scoped Synergia GET surface. Authentication starts on portal.librus.pl; this document covers the subsequent bearer-token calls against api.librus.pl/3.0."
   },
   "servers": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "librus-sdk",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "librus-sdk",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "license": "MIT",
       "dependencies": {
         "@valibot/to-json-schema": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librus-sdk",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "TypeScript SDK and CLI for the Librus family portal flow.",
   "author": "Andrey Koltsov",
   "repository": {


### PR DESCRIPTION
## Summary
- bump package version to 0.6.2
- add 0.6.2 changelog notes for wiadomosci message body decoding
- regenerate OpenAPI metadata

## Verification
- npm run validate
- node ./scripts/extract-release-notes.mjs 0.6.2