### PR TITLE
[codex] Support API backend selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ coverage/
 .env
 .env.integration
 .env.integration.local
+.env.integration.*.local
 .DS_Store
 .claude/
 .serena/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,8 +4,11 @@ Guidance for coding agents working in this repository.
 
 ## Project summary
 
-- This is a TypeScript SDK and CLI for the Librus family portal flow.
-- The supported path is `portal.librus.pl` authentication plus child-scoped `https://api.librus.pl/3.0` requests.
+- This is a TypeScript SDK and CLI for Librus family portal and Gateway API 2.0 flows.
+- Supported backends are:
+  - `api_v3`: `portal.librus.pl` authentication plus child-scoped `https://api.librus.pl/3.0` requests.
+  - `gateway_api_20`: school-issued login/password authentication plus cookie-backed `https://synergia.librus.pl/gateway/api/2.0` requests.
+- `api_v3` is multi-child. `gateway_api_20` is already scoped to one account and must not pretend to support Portal-style child switching.
 - Do not reintroduce the legacy `synergia.librus.pl` HTML-scraping approach.
 - The package exposes both an SDK entrypoint and a CLI binary named `librus`.
 
@@ -49,6 +52,9 @@ npm run cli -- grades list --child <id-or-login>
 ## Environment and secrets
 
 - Runtime credentials come from `LIBRUS_PORTAL_EMAIL` and `LIBRUS_PORTAL_PASSWORD`.
+- Gateway API 2.0 credentials come from `LIBRUS_GATEWAY_LOGIN` and `LIBRUS_GATEWAY_PASSWORD`.
+- Backend selection uses `LIBRUS_API_BACKEND=api_v3|gateway_api_20` when explicit; otherwise complete Portal credentials win, then complete Gateway credentials, then `api_v3` default errors.
+- `LIBRUS_CHILD` is an optional default child selector for `api_v3` only. CLI `--child` wins over `LIBRUS_CHILD`; explicit `--child` is unsupported for `gateway_api_20`.
 - `LIBRUS_EMAIL` and `LIBRUS_PASSWORD` are kept as compatibility fallbacks.
 - Never hardcode credentials, tokens, or session cookies.
 - Keep CLI and SDK errors secret-safe. Do not leak passwords, bearer tokens, or raw cookie values in output, logs, tests, or thrown error messages.
@@ -60,7 +66,8 @@ npm run cli -- grades list --child <id-or-login>
 - Preserve the JSON-first CLI behavior: normal results go to stdout, structured errors go to stderr, and commands should return non-zero exit codes on failure.
 - Follow the existing class boundaries:
   - `PortalClient` handles portal login/session concerns.
-  - `LibrusSession` orchestrates login, child discovery, and child selection.
+  - `GatewayApi20AuthClient` handles Gateway API 2.0 login/session concerns.
+  - `LibrusSession` orchestrates backend selection, login, child discovery, and child selection.
   - `SynergiaApiClient` handles authenticated API calls for a specific child account.
 - Keep compatibility with Node 22+. Node 22 is the supported runtime floor for
   SDK, CLI, CI, and dependency updates.
@@ -73,7 +80,7 @@ npm run cli -- grades list --child <id-or-login>
 
 ## Change guidance
 
-- Preserve the current portal-based flow unless the task explicitly requires architectural change.
+- Preserve existing `api_v3` behavior unless the task explicitly requires architectural change, and keep `gateway_api_20` feature support limited to what the upstream JSON API actually provides.
 - All code and documentation changes should be made outside `master`. Prefer one worktree per active feature and one branch per mergeable change. Prefer branches cut from an up-to-date `master`, but allow short-lived dependent branches when the work is intentionally stacked.
 - Keep public SDK exports intentional and update `README.md` when user-facing CLI or SDK behavior changes.
 - Update `CHANGELOG.md` for notable user-facing changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Gateway API 2.0 login/password authentication through
+  `LIBRUS_GATEWAY_LOGIN` and `LIBRUS_GATEWAY_PASSWORD`, including
+  `LibrusSession.fromGatewayCredentials()` and CLI child-scoped commands that
+  can run without `--child` in `gateway_api_20`.
+- Public API backend selection through `LIBRUS_API_BACKEND`,
+  `LibrusSessionOptions.apiBackend`, and `LibrusSession.getApiBackend()`.
+- Optional `LIBRUS_CHILD` default child selection for `api_v3` CLI commands.
+
+### Changed
+
+- `LIBRUS_EMAIL` and `LIBRUS_PASSWORD` remain documented as deprecated
+  Portal-only compatibility fallbacks. Use `LIBRUS_PORTAL_EMAIL` and
+  `LIBRUS_PORTAL_PASSWORD` for `api_v3`, or `LIBRUS_GATEWAY_LOGIN` and
+  `LIBRUS_GATEWAY_PASSWORD` for `gateway_api_20`.
+- Deprecated compatibility aliases now emit Node deprecation warnings when
+  used.
+
 ## [0.6.2] - 2026-05-17
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -5,11 +5,17 @@
 [![Snyk Security](https://github.com/andrewkoltsov/librus-sdk/actions/workflows/snyk.yml/badge.svg?branch=master)](https://github.com/andrewkoltsov/librus-sdk/actions/workflows/snyk.yml)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/andrewkoltsov/librus-sdk/badge)](https://scorecard.dev/viewer/?uri=github.com/andrewkoltsov/librus-sdk)
 
-Fresh TypeScript SDK and CLI for the Librus family portal flow.
+Fresh TypeScript SDK and CLI for the Librus family portal and Gateway API 2.0
+JSON flows.
 
-This project logs into `portal.librus.pl`, loads linked child accounts from
-`portal/api/v3/SynergiaAccounts`, and uses the selected child account's bearer
-token against `https://api.librus.pl/3.0`.
+For Portal accounts, this project logs into `portal.librus.pl`, loads linked
+child accounts from `portal/api/v3/SynergiaAccounts`, and uses the selected
+child account's bearer token against `https://api.librus.pl/3.0`.
+
+For school-issued accounts, it can also log in with the Gateway API 2.0 login
+and password, keep the resulting Synergia cookies, and read
+`https://synergia.librus.pl/gateway/api/2.0`. That backend is already scoped to
+one account and does not support Portal-only child discovery.
 
 It intentionally does not reuse the legacy `synergia.librus.pl` HTML-scraping
 approach.
@@ -67,21 +73,34 @@ CLI published from this repository.
 `LibrusSession.fromEnv()` and the CLI read credentials and timeout settings from
 these variables:
 
-| Variable                 | Required | Purpose                                                     |
-| ------------------------ | -------- | ----------------------------------------------------------- |
-| `LIBRUS_PORTAL_EMAIL`    | Yes      | Portal login email used for `portal.librus.pl`.             |
-| `LIBRUS_PORTAL_PASSWORD` | Yes      | Portal login password used for `portal.librus.pl`.          |
-| `LIBRUS_EMAIL`           | Fallback | Compatibility alias when `LIBRUS_PORTAL_EMAIL` is unset.    |
-| `LIBRUS_PASSWORD`        | Fallback | Compatibility alias when `LIBRUS_PORTAL_PASSWORD` is unset. |
-| `LIBRUS_TIMEOUT_MS`      | No       | Positive integer request timeout in milliseconds.           |
+| Variable                  | Required | Purpose                                                              |
+| ------------------------- | -------- | -------------------------------------------------------------------- |
+| `LIBRUS_API_BACKEND`      | No       | Optional `api_v3` or `gateway_api_20` selector.                      |
+| `LIBRUS_PORTAL_EMAIL`     | `api_v3` | Portal login email used for `portal.librus.pl`.                      |
+| `LIBRUS_PORTAL_PASSWORD`  | `api_v3` | Portal login password used for `portal.librus.pl`.                   |
+| `LIBRUS_GATEWAY_LOGIN`    | Gateway  | School-issued Gateway API 2.0 login. This is not an email address.   |
+| `LIBRUS_GATEWAY_PASSWORD` | Gateway  | Password for the Gateway API 2.0 login.                              |
+| `LIBRUS_CHILD`            | No       | Optional default child id or login for `api_v3` CLI commands.        |
+| `LIBRUS_EMAIL`            | Fallback | Deprecated Portal-only alias when `LIBRUS_PORTAL_EMAIL` is unset.    |
+| `LIBRUS_PASSWORD`         | Fallback | Deprecated Portal-only alias when `LIBRUS_PORTAL_PASSWORD` is unset. |
+| `LIBRUS_TIMEOUT_MS`       | No       | Positive integer request timeout in milliseconds.                    |
 
 If no timeout is configured, portal and child-scoped SDK requests default to
 `30000` milliseconds. Invalid timeout values fail fast with
 `CONFIGURATION_ERROR`.
 
+When no `LIBRUS_API_BACKEND` is set, complete Portal credentials select
+`api_v3`. If Portal credentials are absent and complete Gateway credentials are
+present, `gateway_api_20` is selected. If neither set is complete, the default
+is `api_v3` so missing-credential errors stay Portal-oriented. When both
+credential sets are complete, `api_v3` wins unless
+`LIBRUS_API_BACKEND=gateway_api_20` is set explicitly.
+
 Empty credential variables are treated as invalid. If a portal-prefixed
-credential variable is set but empty, the compatibility alias for that
-credential is ignored.
+credential variable is set but empty, the deprecated compatibility alias for
+that credential is ignored. `LIBRUS_CHILD` is used only by `api_v3`; CLI
+`--child` wins over `LIBRUS_CHILD`, and explicit `--child` is rejected for
+`gateway_api_20` because that backend is already scoped to one account.
 
 ### Top-Level SDK Entry Points
 
@@ -90,11 +109,13 @@ Import from the package root:
 ```ts
 import {
   BffApiClient,
+  GatewayApi20AuthClient,
   LibrusSession,
   PortalClient,
   SynergiaApiClient,
   generateOpenApiDocument,
   LibrusSdkError,
+  type LibrusApiBackend,
 } from "librus-sdk";
 ```
 
@@ -102,6 +123,7 @@ import {
 | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
 | `LibrusSession`           | Recommended high-level entry point. Handles login, linked-child discovery, child selection, and creation of child-scoped API clients. |
 | `BffApiClient`            | Experimental child-scoped client for selected `https://testbff.librus.pl/v1` mobile backend reads.                                    |
+| `GatewayApi20AuthClient`  | Lower-level Gateway API 2.0 login/password auth client for `synergia.librus.pl/gateway/api/2.0` cookie-backed requests.               |
 | `PortalClient`            | Lower-level portal session client for `portal.librus.pl` login, `/Me`, and `/SynergiaAccounts`.                                       |
 | `SynergiaApiClient`       | Child-scoped GET client for the supported `https://api.librus.pl/3.0` surface when you already have a bearer token.                   |
 | `generateOpenApiDocument` | Generates the shipped OpenAPI document for the supported child-scoped GET subset.                                                     |
@@ -118,11 +140,39 @@ const grades = await client.getGrades();
 console.log(grades);
 ```
 
+Gateway API 2.0 flow:
+
+```bash
+LIBRUS_API_BACKEND=gateway_api_20
+LIBRUS_GATEWAY_LOGIN=1234567
+LIBRUS_GATEWAY_PASSWORD=your-password
+npm exec --package librus-sdk -- librus-sdk grades list
+```
+
+```ts
+import { LibrusSession } from "librus-sdk";
+
+const session = LibrusSession.fromGatewayCredentials({
+  login: "1234567",
+  password: "your-password",
+});
+const client = await session.forChild();
+const grades = await client.getGrades();
+console.log(grades);
+```
+
+Gateway API 2.0 is already child-scoped. `getPortalMe()`,
+`getSynergiaAccounts()`, `listChildren()`, `resolveChild(...)`,
+`forChildBff(...)`, and `forChildWiadomosci(...)` require Portal auth and fail
+with `UNSUPPORTED_BACKEND` in `gateway_api_20`.
+
 Current high-level methods on `LibrusSession`:
 
 - `LibrusSession.fromEnv(env?)`
-- `new LibrusSession({ credentials, portalClient?, portalClientOptions?, bffClientOptions?, synergiaClientOptions?, requestTimeoutMs? })`
+- `LibrusSession.fromGatewayCredentials(credentials, options?)`
+- `new LibrusSession({ apiBackend?, credentials, portalClient?, portalClientOptions?, gatewayApi20AuthClient?, gatewayApi20AuthClientOptions?, bffClientOptions?, synergiaClientOptions?, wiadomosciClientOptions?, requestTimeoutMs? })`
 - `login()`
+- `getApiBackend()`
 - `getPortalMe()`
 - `getSynergiaAccounts()`
 - `listChildren()`
@@ -160,15 +210,21 @@ Attachment-style methods such as `getHomeworkAssignmentAttachment(id)`,
 `getMessageAttachment(id)`, and `getPlannedLessonAttachment(id)` return
 `SynergiaBinaryResult` with `{ data, contentType, contentDisposition }`.
 
-When a `SynergiaApiClient` is created through `LibrusSession.forChild()`,
-message reads use the standard `https://api.librus.pl/3.0` backend by default.
-Use `LibrusSession.forChildWiadomosci()` to opt in to the
-portal-authenticated `https://wiadomosci.librus.pl/api` inbox backend for
-`listMessages()`, `getMessage(id)`, and `getUnreadMessages()`. Other
-child-scoped reads, message receiver groups, and message attachment downloads
-continue to use `https://api.librus.pl/3.0`. Direct
-`new SynergiaApiClient(token)` construction keeps using API 3.0 for all methods
-unless a custom message backend is supplied.
+When a `SynergiaApiClient` is created through `api_v3`
+`LibrusSession.forChild(child)`, reads use bearer-token requests against
+`https://api.librus.pl/3.0` by default. When it is created through
+`gateway_api_20` with `LibrusSession.forChild()` and no child selector, reads
+use cookie-backed requests against
+`https://synergia.librus.pl/gateway/api/2.0` instead; API 3.0 bearer requests
+are not expected to work for that backend.
+
+Use `LibrusSession.forChildWiadomosci()` to opt in to the portal-authenticated
+`https://wiadomosci.librus.pl/api` inbox backend for `listMessages()`,
+`getMessage(id)`, and `getUnreadMessages()`. Other child-scoped reads, message
+receiver groups, and message attachment downloads continue to use the session's
+default Synergia transport. Direct `new SynergiaApiClient(token)` construction
+keeps using API 3.0 for all methods unless lower-level transport options or a
+custom message backend are supplied.
 
 `BffApiClient` currently exposes the research-oriented `listMessages()` method
 for `GET https://testbff.librus.pl/v1/Messages`. It uses the selected child's
@@ -193,13 +249,18 @@ here rather than promising every helper type as a named top-level export.
 
 `LibrusSession` constructor options (`LibrusSessionOptions`):
 
-| Property                | Required | Meaning                                                                              |
-| ----------------------- | -------- | ------------------------------------------------------------------------------------ |
-| `credentials`           | Yes      | Portal credentials object with `email` and `password`.                               |
-| `portalClient`          | No       | Reuse an existing `PortalClient` instance instead of constructing one internally.    |
-| `portalClientOptions`   | No       | Passed to the internally created `PortalClient` when `portalClient` is not supplied. |
-| `synergiaClientOptions` | No       | Passed to `SynergiaApiClient` instances created by `forChild(...)`.                  |
-| `requestTimeoutMs`      | No       | Session-wide default timeout for internally created portal and child clients.        |
+| Property                        | Required | Meaning                                                                              |
+| ------------------------------- | -------- | ------------------------------------------------------------------------------------ |
+| `credentials`                   | Yes      | Portal `{ email, password }` or Gateway `{ login, password }` credentials.           |
+| `apiBackend`                    | No       | `api_v3` by default, or `gateway_api_20` for Gateway API 2.0 credentials.            |
+| `portalClient`                  | No       | Reuse an existing `PortalClient` instance instead of constructing one internally.    |
+| `portalClientOptions`           | No       | Passed to the internally created `PortalClient` when `portalClient` is not supplied. |
+| `gatewayApi20AuthClient`        | No       | Reuse an existing Gateway API 2.0 auth client in `gateway_api_20`.                   |
+| `gatewayApi20AuthClientOptions` | No       | Passed to the internally created Gateway API 2.0 auth client.                        |
+| `bffClientOptions`              | No       | Passed to BFF clients created by `forChildBff(...)`.                                 |
+| `synergiaClientOptions`         | No       | Passed to `SynergiaApiClient` instances created by `forChild(...)`.                  |
+| `wiadomosciClientOptions`       | No       | Passed to wiadomosci-backed clients created by `forChildWiadomosci(...)`.            |
+| `requestTimeoutMs`              | No       | Session-wide default timeout for internally created portal and child clients.        |
 
 `PortalClient` constructor options (`PortalClientOptions`):
 
@@ -218,6 +279,7 @@ here rather than promising every helper type as a named top-level export.
 | ------------------ | -------- | --------------------------------------------------------------- |
 | `fetch`            | No       | Custom fetch implementation for child-scoped API requests.      |
 | `apiBaseUrl`       | No       | Synergia API base URL. Defaults to `https://api.librus.pl/3.0`. |
+| `authMode`         | No       | `bearer` by default, or `cookie` for Gateway-created sessions.  |
 | `requestTimeoutMs` | No       | Positive integer timeout in milliseconds. Defaults to `30000`.  |
 
 `generateOpenApiDocument()` options (`GenerateOpenApiDocumentOptions`):
@@ -247,26 +309,30 @@ Root CLI commands:
 - `librus-sdk --help`
 - `librus-sdk --version`
 
-Every leaf command supports `--format <text|json>`. Child-scoped commands use
-`--child <id-or-login>` to select the linked child account by numeric id or by
-login.
+Every leaf command supports `--format <text|json>`. In `api_v3`, child-scoped
+commands require a child selector: pass `--child <id-or-login>` or set
+`LIBRUS_CHILD`. `--child` wins when both are present. In `gateway_api_20`, the
+account is already child-scoped, so the same commands run without `--child` and
+explicit `--child` fails with `UNSUPPORTED_BACKEND`. Portal-only commands such
+as `children list`, `messages bff-list`, and `messages wiadomosci-list` are not
+available in `gateway_api_20`.
 
-| Family           | Subcommands                                                                                                 | Extra selectors and flags                                                                                                                                                                                                                    |
-| ---------------- | ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `children`       | `list`                                                                                                      | No child selector.                                                                                                                                                                                                                           |
-| `me`             | root command                                                                                                | `--child`.                                                                                                                                                                                                                                   |
-| `grades`         | `list`                                                                                                      | `--child`.                                                                                                                                                                                                                                   |
-| `attendance`     | `list`                                                                                                      | `--child`.                                                                                                                                                                                                                                   |
-| `homework`       | `list`                                                                                                      | `--child`.                                                                                                                                                                                                                                   |
-| `messages`       | `list`, `bff-list`, `get`, `unread`, `wiadomosci-list`, `wiadomosci-get`, `wiadomosci-unread`               | `list`, `get`, and `unread` support `--backend <api3\|wiadomosci>` and default to `api3`; `wiadomosci-list` supports `--after-id <id>`; `bff-list` reads the experimental BFF inbox payload; `get` and `wiadomosci-get` require `--id <id>`. |
-| `timetable`      | `week`, `day`, `entry`                                                                                      | `week` requires `--week-start <YYYY-MM-DD>`; `day` requires `--day <YYYY-MM-DD>`; `entry` requires `--id <id>`.                                                                                                                              |
-| `announcements`  | `list`, `get`                                                                                               | `get` requires `--id <id>`.                                                                                                                                                                                                                  |
-| `notes`          | `list`, `get`                                                                                               | `get` requires `--id <id>`.                                                                                                                                                                                                                  |
-| `lessons`        | `list`, `get`, `planned-list`, `planned-get`, `planned-attachment`, `realizations-list`, `realizations-get` | `get`, `planned-get`, and `realizations-get` require `--id <id>`; `planned-attachment` requires `--id <id>` and `--output <path>`.                                                                                                           |
-| `lucky-number`   | `get`                                                                                                       | Optional `--for-day <YYYY-MM-DD>`.                                                                                                                                                                                                           |
-| `notifications`  | `center`, `push-configurations`                                                                             | `--child`.                                                                                                                                                                                                                                   |
-| `justifications` | `list`, `get`, `conferences`, `system-data`                                                                 | `list` supports `--date-from <YYYY-MM-DD>`; `get` requires `--id <id>`.                                                                                                                                                                      |
-| `auth`           | `photos`, `photo`, `user-info`, `token-info`, `classroom`                                                   | `photo` requires `--id <id>` and `--output <path>`; `user-info` and `classroom` require `--id <id>`.                                                                                                                                         |
+| Family           | Subcommands                                                                                                 | Extra selectors and flags                                                                                                                                                                          |
+| ---------------- | ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `children`       | `list`                                                                                                      | Portal-only; no child selector.                                                                                                                                                                    |
+| `me`             | root command                                                                                                | `api_v3` requires a child selector; `gateway_api_20` does not.                                                                                                                                     |
+| `grades`         | `list`                                                                                                      | `api_v3` requires a child selector; `gateway_api_20` does not.                                                                                                                                     |
+| `attendance`     | `list`                                                                                                      | `api_v3` requires a child selector; `gateway_api_20` does not.                                                                                                                                     |
+| `homework`       | `list`                                                                                                      | `api_v3` requires a child selector; `gateway_api_20` does not.                                                                                                                                     |
+| `messages`       | `list`, `bff-list`, `get`, `unread`, `wiadomosci-list`, `wiadomosci-get`, `wiadomosci-unread`               | `list`, `get`, and `unread` support `--backend <api3\|wiadomosci>` and default to `api3`; `get` and `wiadomosci-get` require `--id <id>`; `bff-*` and `wiadomosci-*` are Portal-only.              |
+| `timetable`      | `week`, `day`, `entry`                                                                                      | `week` requires `--week-start <YYYY-MM-DD>`; `day` requires `--day <YYYY-MM-DD>`; `entry` requires `--id <id>`; `api_v3` requires a child selector; `gateway_api_20` does not.                     |
+| `announcements`  | `list`, `get`                                                                                               | `get` requires `--id <id>`; `api_v3` requires a child selector; `gateway_api_20` does not.                                                                                                         |
+| `notes`          | `list`, `get`                                                                                               | `get` requires `--id <id>`; `api_v3` requires a child selector; `gateway_api_20` does not.                                                                                                         |
+| `lessons`        | `list`, `get`, `planned-list`, `planned-get`, `planned-attachment`, `realizations-list`, `realizations-get` | `get`, `planned-get`, and `realizations-get` require `--id <id>`; `planned-attachment` requires `--id <id>` and `--output <path>`; `api_v3` requires a child selector; `gateway_api_20` does not.  |
+| `lucky-number`   | `get`                                                                                                       | Optional `--for-day <YYYY-MM-DD>`; `api_v3` requires a child selector; `gateway_api_20` does not.                                                                                                  |
+| `notifications`  | `center`, `push-configurations`                                                                             | `api_v3` requires a child selector; `gateway_api_20` does not.                                                                                                                                     |
+| `justifications` | `list`, `get`, `conferences`, `system-data`                                                                 | `list` supports `--date-from <YYYY-MM-DD>`; `get` requires `--id <id>`; `api_v3` requires a child selector; `gateway_api_20` does not.                                                             |
+| `auth`           | `photos`, `photo`, `user-info`, `token-info`, `classroom`                                                   | `photo` requires `--id <id>` and `--output <path>`; `user-info` and `classroom` require `--id <id>`; `api_v3` requires a child selector for child-scoped auth commands; `gateway_api_20` does not. |
 
 ### CLI Output Contract
 
@@ -275,7 +341,9 @@ login.
 - Errors are written to stderr and follow the selected output format.
 - Non-successful commands return a non-zero exit code.
 - `children list` JSON output is `{ lastModification, children }`.
-- Child-scoped read commands emit `{ child, data }` in JSON output.
+- Child-scoped read commands emit `{ child, data }` in JSON output for `api_v3`
+  and `{ data }` for `gateway_api_20`, where the session is already
+  child-scoped.
 - Download commands such as `lessons planned-attachment` and `auth photo`
   write the requested file first, then report saved-file metadata instead of raw
   bytes. JSON output keeps the same `{ child, data }` envelope, where `data`
@@ -318,7 +386,7 @@ Current codes emitted by the SDK and CLI:
 | Code                         | Meaning                                                                    |
 | ---------------------------- | -------------------------------------------------------------------------- |
 | `CONFIGURATION_ERROR`        | Required credentials or other local configuration are missing or invalid.  |
-| `AUTHENTICATION_FAILED`      | Portal login or post-login verification failed.                            |
+| `AUTHENTICATION_FAILED`      | Portal or Gateway API 2.0 authentication failed.                           |
 | `PORTAL_LOGIN_PAGE_INVALID`  | The portal login page no longer matches the expected CSRF-token structure. |
 | `NETWORK_TIMEOUT`            | A portal or Synergia request exceeded the configured timeout.              |
 | `API_REQUEST_FAILED`         | A portal or Synergia request failed with a non-maintenance HTTP error.     |
@@ -326,6 +394,8 @@ Current codes emitted by the SDK and CLI:
 | `RESPONSE_VALIDATION_FAILED` | The live payload no longer matches the validated SDK schema.               |
 | `CHILD_NOT_FOUND`            | No linked child account matched the provided selector.                     |
 | `AMBIGUOUS_CHILD`            | More than one linked child account matched the provided selector.          |
+| `CHILD_REQUIRED`             | `api_v3` needs `--child`, `LIBRUS_CHILD`, or an SDK child selector.        |
+| `UNSUPPORTED_BACKEND`        | The selected API backend cannot support the requested operation.           |
 | `CLI_USAGE_ERROR`            | The CLI arguments were invalid, incomplete, or used unsupported values.    |
 | `INTERNAL_ERROR`             | Unexpected non-SDK error wrapper used by the CLI fallback path.            |
 
@@ -464,14 +534,14 @@ They are intended for local manual verification only:
 - they are not part of `npm run validate`
 - they are not run in CI or release automation
 
-Create a dedicated local env file:
+Create a dedicated Portal env file at `.env.integration.local`:
 
 ```bash
 LIBRUS_PORTAL_EMAIL=you@example.com
 LIBRUS_PORTAL_PASSWORD=your-password
 ```
 
-Save it as `.env.integration.local`, then run:
+Then run:
 
 ```bash
 npm run test:integration
@@ -483,8 +553,38 @@ npm run report:integration:sdk
 npm run report:integration:cli
 ```
 
-To limit the live run to specific children, set `LIBRUS_TEST_CHILDREN` as a
-comma-separated list of child ids or logins:
+For Gateway API 2.0 verification, create
+`.env.integration.gateway-api-20.local` with the school-issued login. The login
+is printed or issued by the school; it is not an email address.
+
+```bash
+LIBRUS_GATEWAY_LOGIN=1234567
+LIBRUS_GATEWAY_PASSWORD=your-password
+```
+
+Then run:
+
+```bash
+npm run test:integration:gateway-api-20
+npm run test:integration:gateway-api-20:sdk
+npm run test:integration:gateway-api-20:cli
+
+npm run report:integration:gateway-api-20
+npm run report:integration:gateway-api-20:sdk
+npm run report:integration:gateway-api-20:cli
+```
+
+The Gateway API 2.0 integration scripts force
+`LIBRUS_API_BACKEND=gateway_api_20`, so a developer shell with Portal variables
+set will not accidentally run the Portal matrix. The Gateway matrix is already
+child-scoped: SDK checks use `session.forChild()` without a selector, and CLI
+checks run commands such as `librus-sdk grades list` without `--child`.
+Portal-only checks are skipped in the Gateway report because
+`gateway_api_20` cannot list Portal-linked children or create Portal-backed
+BFF/wiadomosci clients.
+
+To limit the Portal live run to specific children, set `LIBRUS_TEST_CHILDREN` as
+a comma-separated list of child ids or logins:
 
 ```bash
 LIBRUS_TEST_CHILDREN=7147345 npm run test:integration

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "librus-sdk",
   "version": "0.6.2",
-  "description": "TypeScript SDK and CLI for the Librus family portal flow.",
+  "description": "TypeScript SDK and CLI for Librus family portal and Gateway API 2.0 flows.",
   "author": "Andrey Koltsov",
   "repository": {
     "type": "git",
@@ -42,6 +42,12 @@
     "report:integration": "npm run build && node --env-file=.env.integration.local test/integration/report-all.mjs",
     "report:integration:cli": "npm run build && node --env-file=.env.integration.local test/integration/report-cli.mjs",
     "report:integration:sdk": "npm run build && node --env-file=.env.integration.local test/integration/report-sdk.mjs",
+    "report:integration:gateway-api-20": "npm run build && LIBRUS_API_BACKEND=gateway_api_20 node --env-file=.env.integration.gateway-api-20.local test/integration/report-all.mjs",
+    "report:integration:gateway-api-20:cli": "npm run build && LIBRUS_API_BACKEND=gateway_api_20 node --env-file=.env.integration.gateway-api-20.local test/integration/report-cli.mjs",
+    "report:integration:gateway-api-20:sdk": "npm run build && LIBRUS_API_BACKEND=gateway_api_20 node --env-file=.env.integration.gateway-api-20.local test/integration/report-sdk.mjs",
+    "report:integration:synergia": "npm run build && LIBRUS_API_BACKEND=gateway_api_20 node --env-file=.env.integration.synergia.local test/integration/report-all.mjs",
+    "report:integration:synergia:cli": "npm run build && LIBRUS_API_BACKEND=gateway_api_20 node --env-file=.env.integration.synergia.local test/integration/report-cli.mjs",
+    "report:integration:synergia:sdk": "npm run build && LIBRUS_API_BACKEND=gateway_api_20 node --env-file=.env.integration.synergia.local test/integration/report-sdk.mjs",
     "validate": "npm run lint && npm run format:check && npm run build && npm run test:coverage && npm run pack:check",
     "prepublishOnly": "npm run validate",
     "prepare": "husky",
@@ -49,7 +55,13 @@
     "test:coverage": "vitest run --coverage",
     "test:integration": "npm run build && node --env-file=.env.integration.local --test test/integration/*.integration.test.mjs",
     "test:integration:cli": "npm run build && node --env-file=.env.integration.local --test test/integration/cli.integration.test.mjs",
-    "test:integration:sdk": "npm run build && node --env-file=.env.integration.local --test test/integration/sdk.integration.test.mjs"
+    "test:integration:sdk": "npm run build && node --env-file=.env.integration.local --test test/integration/sdk.integration.test.mjs",
+    "test:integration:gateway-api-20": "npm run build && LIBRUS_API_BACKEND=gateway_api_20 node --env-file=.env.integration.gateway-api-20.local --test test/integration/*.integration.test.mjs",
+    "test:integration:gateway-api-20:cli": "npm run build && LIBRUS_API_BACKEND=gateway_api_20 node --env-file=.env.integration.gateway-api-20.local --test test/integration/cli.integration.test.mjs",
+    "test:integration:gateway-api-20:sdk": "npm run build && LIBRUS_API_BACKEND=gateway_api_20 node --env-file=.env.integration.gateway-api-20.local --test test/integration/sdk.integration.test.mjs",
+    "test:integration:synergia": "npm run build && LIBRUS_API_BACKEND=gateway_api_20 node --env-file=.env.integration.synergia.local --test test/integration/*.integration.test.mjs",
+    "test:integration:synergia:cli": "npm run build && LIBRUS_API_BACKEND=gateway_api_20 node --env-file=.env.integration.synergia.local --test test/integration/cli.integration.test.mjs",
+    "test:integration:synergia:sdk": "npm run build && LIBRUS_API_BACKEND=gateway_api_20 node --env-file=.env.integration.synergia.local --test test/integration/sdk.integration.test.mjs"
   },
   "files": [
     "dist",

--- a/scripts/verify-published-package.mjs
+++ b/scripts/verify-published-package.mjs
@@ -80,6 +80,7 @@ export function fetchPublishedPackageMetadata(packageSpec) {
   }
 }
 
+/* v8 ignore next -- covered by release workflow smoke usage instead of unit import. */
 if (import.meta.url === pathToFileURL(resolve(process.argv[1] ?? "")).href) {
   const [, , packageName, packageVersion] = process.argv;
 

--- a/src/cli/commands/announcements.ts
+++ b/src/cli/commands/announcements.ts
@@ -3,9 +3,11 @@ import { Command } from "commander";
 import type { CliContext } from "./common.js";
 import {
   addFormatOption,
+  addChildOption,
   configureCommand,
+  createChildApiClient,
   type CliFormatOptions,
-  writeChildScopedOutput,
+  writeOptionalChildScopedOutput,
 } from "./common.js";
 
 export function createAnnouncementsCommand(context: CliContext): Command {
@@ -14,38 +16,44 @@ export function createAnnouncementsCommand(context: CliContext): Command {
     context,
   );
   const list = configureCommand(
-    addFormatOption(
-      new Command("list").description("List school announcements"),
+    addChildOption(
+      addFormatOption(
+        new Command("list").description("List school announcements"),
+      ),
     ),
     context,
   );
   const get = configureCommand(
-    addFormatOption(
-      new Command("get").description("Get a school announcement by id"),
+    addChildOption(
+      addFormatOption(
+        new Command("get").description("Get a school announcement by id"),
+      ),
     ),
     context,
   );
 
-  list.requiredOption("--child <id-or-login>", "Child account id or login");
-  list.action(async (options: CliFormatOptions & { child: string }) => {
+  list.action(async (options: CliFormatOptions & { child?: string }) => {
     const session = context.createSession();
-    const child = await session.resolveChild(options.child);
-    const client = await session.forChild(child);
+    const { child, client } = await createChildApiClient(
+      session,
+      options.child,
+    );
     const data = await client.listSchoolNotices();
 
-    writeChildScopedOutput(context, options.format, child, data);
+    writeOptionalChildScopedOutput(context, options.format, child, data);
   });
 
-  get.requiredOption("--child <id-or-login>", "Child account id or login");
   get.requiredOption("--id <id>", "Announcement id");
   get.action(
-    async (options: CliFormatOptions & { child: string; id: string }) => {
+    async (options: CliFormatOptions & { child?: string; id: string }) => {
       const session = context.createSession();
-      const child = await session.resolveChild(options.child);
-      const client = await session.forChild(child);
+      const { child, client } = await createChildApiClient(
+        session,
+        options.child,
+      );
       const data = await client.getSchoolNotice(options.id);
 
-      writeChildScopedOutput(context, options.format, child, data);
+      writeOptionalChildScopedOutput(context, options.format, child, data);
     },
   );
 

--- a/src/cli/commands/attendance.ts
+++ b/src/cli/commands/attendance.ts
@@ -3,9 +3,11 @@ import { Command } from "commander";
 import type { CliContext } from "./common.js";
 import {
   addFormatOption,
+  addChildOption,
   configureCommand,
+  createChildApiClient,
   type CliFormatOptions,
-  writeChildScopedOutput,
+  writeOptionalChildScopedOutput,
 } from "./common.js";
 
 export function createAttendanceCommand(context: CliContext): Command {
@@ -14,20 +16,23 @@ export function createAttendanceCommand(context: CliContext): Command {
     context,
   );
   const list = configureCommand(
-    addFormatOption(
-      new Command("list").description("List attendances for a child"),
+    addChildOption(
+      addFormatOption(
+        new Command("list").description("List attendances for a child"),
+      ),
     ),
     context,
   );
 
-  list.requiredOption("--child <id-or-login>", "Child account id or login");
-  list.action(async (options: CliFormatOptions & { child: string }) => {
+  list.action(async (options: CliFormatOptions & { child?: string }) => {
     const session = context.createSession();
-    const child = await session.resolveChild(options.child);
-    const client = await session.forChild(child);
+    const { child, client } = await createChildApiClient(
+      session,
+      options.child,
+    );
     const data = await client.getAttendances();
 
-    writeChildScopedOutput(context, options.format, child, data);
+    writeOptionalChildScopedOutput(context, options.format, child, data);
   });
 
   attendance.addCommand(list);

--- a/src/cli/commands/auth.ts
+++ b/src/cli/commands/auth.ts
@@ -5,11 +5,13 @@ import type { AuthPhoto } from "../../sdk/models/synergia/auth.js";
 import type { CliContext } from "./common.js";
 import {
   addFormatOption,
+  addChildOption,
   configureCommand,
+  createChildApiClient,
   createSingleDataSection,
   type CliFormatOptions,
   writeBase64Download,
-  writeChildScopedOutput,
+  writeOptionalChildScopedOutput,
 } from "./common.js";
 
 function inferContentTypeFromFileName(fileName?: string): string | null {
@@ -58,58 +60,70 @@ export function createAuthCommand(context: CliContext): Command {
     context,
   );
   const photos = configureCommand(
-    addFormatOption(new Command("photos").description("List auth photos")),
+    addChildOption(
+      addFormatOption(new Command("photos").description("List auth photos")),
+    ),
     context,
   );
   const photo = configureCommand(
-    addFormatOption(
-      new Command("photo").description("Download an auth photo by id"),
+    addChildOption(
+      addFormatOption(
+        new Command("photo").description("Download an auth photo by id"),
+      ),
     ),
     context,
   );
   const userInfo = configureCommand(
-    addFormatOption(
-      new Command("user-info").description("Get auth user info by id"),
+    addChildOption(
+      addFormatOption(
+        new Command("user-info").description("Get auth user info by id"),
+      ),
     ),
     context,
   );
   const tokenInfo = configureCommand(
-    addFormatOption(
-      new Command("token-info").description("Get auth token info"),
+    addChildOption(
+      addFormatOption(
+        new Command("token-info").description("Get auth token info"),
+      ),
     ),
     context,
   );
   const classroom = configureCommand(
-    addFormatOption(
-      new Command("classroom").description("Get auth classroom data by id"),
+    addChildOption(
+      addFormatOption(
+        new Command("classroom").description("Get auth classroom data by id"),
+      ),
     ),
     context,
   );
 
-  photos.requiredOption("--child <id-or-login>", "Child account id or login");
-  photos.action(async (options: CliFormatOptions & { child: string }) => {
+  photos.action(async (options: CliFormatOptions & { child?: string }) => {
     const session = context.createSession();
-    const child = await session.resolveChild(options.child);
-    const client = await session.forChild(child);
+    const { child, client } = await createChildApiClient(
+      session,
+      options.child,
+    );
     const data = await client.listAuthPhotos();
 
-    writeChildScopedOutput(context, options.format, child, data);
+    writeOptionalChildScopedOutput(context, options.format, child, data);
   });
 
-  photo.requiredOption("--child <id-or-login>", "Child account id or login");
   photo.requiredOption("--id <id>", "Photo id");
   photo.requiredOption("--output <path>", "Write the photo to this file path");
   photo.action(
     async (
       options: CliFormatOptions & {
-        child: string;
+        child?: string;
         id: string;
         output: string;
       },
     ) => {
       const session = context.createSession();
-      const child = await session.resolveChild(options.child);
-      const client = await session.forChild(child);
+      const { child, client } = await createChildApiClient(
+        session,
+        options.child,
+      );
       const response = await client.getAuthPhoto(options.id);
       const photoData = response.data.photo ?? null;
       const data = writeBase64Download(
@@ -121,58 +135,58 @@ export function createAuthCommand(context: CliContext): Command {
         },
       );
 
-      writeChildScopedOutput(
+      writeOptionalChildScopedOutput(
         context,
         options.format,
         child,
         data,
-        (summary) => [
-          { title: "Child", value: summary },
-          ...createSingleDataSection("Saved File", data),
-        ],
+        (summary) =>
+          summary
+            ? [
+                { title: "Child", value: summary },
+                ...createSingleDataSection("Saved File", data),
+              ]
+            : createSingleDataSection("Saved File", data),
       );
     },
   );
 
-  userInfo.requiredOption("--child <id-or-login>", "Child account id or login");
   userInfo.requiredOption("--id <id>", "User identifier");
   userInfo.action(
-    async (options: CliFormatOptions & { child: string; id: string }) => {
+    async (options: CliFormatOptions & { child?: string; id: string }) => {
       const session = context.createSession();
-      const child = await session.resolveChild(options.child);
-      const client = await session.forChild(child);
+      const { child, client } = await createChildApiClient(
+        session,
+        options.child,
+      );
       const data = await client.getAuthUserInfo(options.id);
 
-      writeChildScopedOutput(context, options.format, child, data);
+      writeOptionalChildScopedOutput(context, options.format, child, data);
     },
   );
 
-  tokenInfo.requiredOption(
-    "--child <id-or-login>",
-    "Child account id or login",
-  );
-  tokenInfo.action(async (options: CliFormatOptions & { child: string }) => {
+  tokenInfo.action(async (options: CliFormatOptions & { child?: string }) => {
     const session = context.createSession();
-    const child = await session.resolveChild(options.child);
-    const client = await session.forChild(child);
+    const { child, client } = await createChildApiClient(
+      session,
+      options.child,
+    );
     const data = await client.getAuthTokenInfo();
 
-    writeChildScopedOutput(context, options.format, child, data);
+    writeOptionalChildScopedOutput(context, options.format, child, data);
   });
 
-  classroom.requiredOption(
-    "--child <id-or-login>",
-    "Child account id or login",
-  );
   classroom.requiredOption("--id <id>", "Classroom id");
   classroom.action(
-    async (options: CliFormatOptions & { child: string; id: string }) => {
+    async (options: CliFormatOptions & { child?: string; id: string }) => {
       const session = context.createSession();
-      const child = await session.resolveChild(options.child);
-      const client = await session.forChild(child);
+      const { child, client } = await createChildApiClient(
+        session,
+        options.child,
+      );
       const data = await client.getAuthClassroom(options.id);
 
-      writeChildScopedOutput(context, options.format, child, data);
+      writeOptionalChildScopedOutput(context, options.format, child, data);
     },
   );
 

--- a/src/cli/commands/common.ts
+++ b/src/cli/commands/common.ts
@@ -6,6 +6,8 @@ import {
   LibrusSdkError,
   type ChildAccount,
   type ChildAccountSummary,
+  type LibrusApiBackend,
+  type SynergiaApiClient,
 } from "../../sdk/index.js";
 import { renderTextSections, type CliTextSection } from "../output/render.js";
 
@@ -56,6 +58,57 @@ export function addFormatOption(command: Command): Command {
     parseCliOutputFormat,
     "text",
   );
+}
+
+export function addChildOption(command: Command): Command {
+  return command.option("--child <id-or-login>", "Child account id or login");
+}
+
+export async function createChildApiClient(
+  session: LibrusSession,
+  childSelector?: string,
+): Promise<{ child?: ChildAccount; client: SynergiaApiClient }> {
+  const apiBackend = getSessionApiBackend(session);
+
+  if (apiBackend === "gateway_api_20") {
+    if (childSelector) {
+      throw new LibrusSdkError(
+        "UNSUPPORTED_BACKEND",
+        "--child is not supported with gateway_api_20 because the gateway session is already scoped to one account.",
+        { apiBackend },
+      );
+    }
+
+    return {
+      client: await session.forChild(),
+    };
+  }
+
+  const resolvedChildSelector = resolveApiV3ChildSelector(childSelector);
+
+  if (!resolvedChildSelector) {
+    throw new LibrusSdkError(
+      "CHILD_REQUIRED",
+      "Child account id or login is required for api_v3. Pass --child <id-or-login> or set LIBRUS_CHILD.",
+    );
+  }
+
+  const child = await session.resolveChild(resolvedChildSelector);
+
+  return {
+    child,
+    client: await session.forChild(child),
+  };
+}
+
+export function getSessionApiBackend(session: LibrusSession): LibrusApiBackend {
+  return session.getApiBackend();
+}
+
+export function resolveApiV3ChildSelector(
+  childSelector?: string,
+): string | undefined {
+  return childSelector ?? process.env.LIBRUS_CHILD;
 }
 
 export function summarizeChildAccount(
@@ -270,6 +323,33 @@ export function writeChildScopedOutput(
     buildTextSections
       ? buildTextSections(summary)
       : createChildScopedSections(summary, data),
+  );
+}
+
+export function writeOptionalChildScopedOutput(
+  context: CliContext,
+  format: CliOutputFormat,
+  child: ChildAccount | undefined,
+  data: unknown,
+  buildTextSections:
+    | ((child: ChildAccountSummary | undefined) => CliTextSection[])
+    | null = null,
+): void {
+  if (child) {
+    writeChildScopedOutput(context, format, child, data, (summary) =>
+      buildTextSections
+        ? buildTextSections(summary)
+        : createChildScopedSections(summary, data),
+    );
+    return;
+  }
+
+  const payload = { data };
+
+  writeCommandOutput(context, format, payload, () =>
+    buildTextSections
+      ? buildTextSections(undefined)
+      : createTopLevelDataSections(data),
   );
 }
 

--- a/src/cli/commands/grades.ts
+++ b/src/cli/commands/grades.ts
@@ -3,9 +3,11 @@ import { Command } from "commander";
 import type { CliContext } from "./common.js";
 import {
   addFormatOption,
+  addChildOption,
   configureCommand,
+  createChildApiClient,
   type CliFormatOptions,
-  writeChildScopedOutput,
+  writeOptionalChildScopedOutput,
 } from "./common.js";
 
 export function createGradesCommand(context: CliContext): Command {
@@ -14,18 +16,23 @@ export function createGradesCommand(context: CliContext): Command {
     context,
   );
   const list = configureCommand(
-    addFormatOption(new Command("list").description("List grades for a child")),
+    addChildOption(
+      addFormatOption(
+        new Command("list").description("List grades for a child"),
+      ),
+    ),
     context,
   );
 
-  list.requiredOption("--child <id-or-login>", "Child account id or login");
-  list.action(async (options: CliFormatOptions & { child: string }) => {
+  list.action(async (options: CliFormatOptions & { child?: string }) => {
     const session = context.createSession();
-    const child = await session.resolveChild(options.child);
-    const client = await session.forChild(child);
+    const { child, client } = await createChildApiClient(
+      session,
+      options.child,
+    );
     const data = await client.getGrades();
 
-    writeChildScopedOutput(context, options.format, child, data);
+    writeOptionalChildScopedOutput(context, options.format, child, data);
   });
 
   grades.addCommand(list);

--- a/src/cli/commands/homework.ts
+++ b/src/cli/commands/homework.ts
@@ -3,9 +3,11 @@ import { Command } from "commander";
 import type { CliContext } from "./common.js";
 import {
   addFormatOption,
+  addChildOption,
   configureCommand,
+  createChildApiClient,
   type CliFormatOptions,
-  writeChildScopedOutput,
+  writeOptionalChildScopedOutput,
 } from "./common.js";
 
 export function createHomeworkCommand(context: CliContext): Command {
@@ -14,20 +16,23 @@ export function createHomeworkCommand(context: CliContext): Command {
     context,
   );
   const list = configureCommand(
-    addFormatOption(
-      new Command("list").description("List homework for a child"),
+    addChildOption(
+      addFormatOption(
+        new Command("list").description("List homework for a child"),
+      ),
     ),
     context,
   );
 
-  list.requiredOption("--child <id-or-login>", "Child account id or login");
-  list.action(async (options: CliFormatOptions & { child: string }) => {
+  list.action(async (options: CliFormatOptions & { child?: string }) => {
     const session = context.createSession();
-    const child = await session.resolveChild(options.child);
-    const client = await session.forChild(child);
+    const { child, client } = await createChildApiClient(
+      session,
+      options.child,
+    );
     const data = await client.getHomeWorks();
 
-    writeChildScopedOutput(context, options.format, child, data);
+    writeOptionalChildScopedOutput(context, options.format, child, data);
   });
 
   homework.addCommand(list);

--- a/src/cli/commands/justifications.ts
+++ b/src/cli/commands/justifications.ts
@@ -3,9 +3,11 @@ import { Command } from "commander";
 import type { CliContext } from "./common.js";
 import {
   addFormatOption,
+  addChildOption,
   configureCommand,
+  createChildApiClient,
   type CliFormatOptions,
-  writeChildScopedOutput,
+  writeOptionalChildScopedOutput,
 } from "./common.js";
 
 export function createJustificationsCommand(context: CliContext): Command {
@@ -14,85 +16,93 @@ export function createJustificationsCommand(context: CliContext): Command {
     context,
   );
   const list = configureCommand(
-    addFormatOption(new Command("list").description("List justifications")),
+    addChildOption(
+      addFormatOption(new Command("list").description("List justifications")),
+    ),
     context,
   );
   const get = configureCommand(
-    addFormatOption(
-      new Command("get").description("Get a justification by id"),
+    addChildOption(
+      addFormatOption(
+        new Command("get").description("Get a justification by id"),
+      ),
     ),
     context,
   );
   const conferences = configureCommand(
-    addFormatOption(
-      new Command("conferences").description("List parent-teacher conferences"),
+    addChildOption(
+      addFormatOption(
+        new Command("conferences").description(
+          "List parent-teacher conferences",
+        ),
+      ),
     ),
     context,
   );
   const systemData = configureCommand(
-    addFormatOption(
-      new Command("system-data").description("Get system date and time"),
+    addChildOption(
+      addFormatOption(
+        new Command("system-data").description("Get system date and time"),
+      ),
     ),
     context,
   );
 
-  list.requiredOption("--child <id-or-login>", "Child account id or login");
   list.option(
     "--date-from <YYYY-MM-DD>",
     "Request justifications from this date onward",
   );
   list.action(
     async (
-      options: CliFormatOptions & { child: string; dateFrom?: string },
+      options: CliFormatOptions & { child?: string; dateFrom?: string },
     ) => {
       const session = context.createSession();
-      const child = await session.resolveChild(options.child);
-      const client = await session.forChild(child);
+      const { child, client } = await createChildApiClient(
+        session,
+        options.child,
+      );
       const data = await client.listJustifications(
         options.dateFrom ? { dateFrom: options.dateFrom } : {},
       );
 
-      writeChildScopedOutput(context, options.format, child, data);
+      writeOptionalChildScopedOutput(context, options.format, child, data);
     },
   );
 
-  get.requiredOption("--child <id-or-login>", "Child account id or login");
   get.requiredOption("--id <id>", "Justification id");
   get.action(
-    async (options: CliFormatOptions & { child: string; id: string }) => {
+    async (options: CliFormatOptions & { child?: string; id: string }) => {
       const session = context.createSession();
-      const child = await session.resolveChild(options.child);
-      const client = await session.forChild(child);
+      const { child, client } = await createChildApiClient(
+        session,
+        options.child,
+      );
       const data = await client.getJustification(options.id);
 
-      writeChildScopedOutput(context, options.format, child, data);
+      writeOptionalChildScopedOutput(context, options.format, child, data);
     },
   );
 
-  conferences.requiredOption(
-    "--child <id-or-login>",
-    "Child account id or login",
-  );
-  conferences.action(async (options: CliFormatOptions & { child: string }) => {
+  conferences.action(async (options: CliFormatOptions & { child?: string }) => {
     const session = context.createSession();
-    const child = await session.resolveChild(options.child);
-    const client = await session.forChild(child);
+    const { child, client } = await createChildApiClient(
+      session,
+      options.child,
+    );
     const data = await client.listParentTeacherConferences();
 
-    writeChildScopedOutput(context, options.format, child, data);
+    writeOptionalChildScopedOutput(context, options.format, child, data);
   });
 
-  systemData.requiredOption(
-    "--child <id-or-login>",
-    "Child account id or login",
-  );
-  systemData.action(async (options: CliFormatOptions & { child: string }) => {
+  systemData.action(async (options: CliFormatOptions & { child?: string }) => {
     const session = context.createSession();
-    const child = await session.resolveChild(options.child);
-    const client = await session.forChild(child);
+    const { child, client } = await createChildApiClient(
+      session,
+      options.child,
+    );
     const data = await client.getSystemData();
 
-    writeChildScopedOutput(context, options.format, child, data);
+    writeOptionalChildScopedOutput(context, options.format, child, data);
   });
 
   justifications.addCommand(list);

--- a/src/cli/commands/lessons.ts
+++ b/src/cli/commands/lessons.ts
@@ -3,11 +3,13 @@ import { Command } from "commander";
 import type { CliContext } from "./common.js";
 import {
   addFormatOption,
+  addChildOption,
   configureCommand,
+  createChildApiClient,
   createSingleDataSection,
   type CliFormatOptions,
   writeBinaryDownload,
-  writeChildScopedOutput,
+  writeOptionalChildScopedOutput,
 } from "./common.js";
 
 export function createLessonsCommand(context: CliContext): Command {
@@ -16,104 +18,114 @@ export function createLessonsCommand(context: CliContext): Command {
     context,
   );
   const list = configureCommand(
-    addFormatOption(new Command("list").description("List lessons")),
+    addChildOption(
+      addFormatOption(new Command("list").description("List lessons")),
+    ),
     context,
   );
   const get = configureCommand(
-    addFormatOption(new Command("get").description("Get a lesson by id")),
+    addChildOption(
+      addFormatOption(new Command("get").description("Get a lesson by id")),
+    ),
     context,
   );
   const plannedList = configureCommand(
-    addFormatOption(
-      new Command("planned-list").description("List planned lessons"),
+    addChildOption(
+      addFormatOption(
+        new Command("planned-list").description("List planned lessons"),
+      ),
     ),
     context,
   );
   const plannedGet = configureCommand(
-    addFormatOption(
-      new Command("planned-get").description("Get a planned lesson by id"),
+    addChildOption(
+      addFormatOption(
+        new Command("planned-get").description("Get a planned lesson by id"),
+      ),
     ),
     context,
   );
   const plannedAttachment = configureCommand(
-    addFormatOption(
-      new Command("planned-attachment").description(
-        "Download a planned lesson attachment",
+    addChildOption(
+      addFormatOption(
+        new Command("planned-attachment").description(
+          "Download a planned lesson attachment",
+        ),
       ),
     ),
     context,
   );
   const realizationsList = configureCommand(
-    addFormatOption(
-      new Command("realizations-list").description("List lesson realizations"),
+    addChildOption(
+      addFormatOption(
+        new Command("realizations-list").description(
+          "List lesson realizations",
+        ),
+      ),
     ),
     context,
   );
   const realizationsGet = configureCommand(
-    addFormatOption(
-      new Command("realizations-get").description(
-        "Get a lesson realization by id",
+    addChildOption(
+      addFormatOption(
+        new Command("realizations-get").description(
+          "Get a lesson realization by id",
+        ),
       ),
     ),
     context,
   );
 
-  list.requiredOption("--child <id-or-login>", "Child account id or login");
-  list.action(async (options: CliFormatOptions & { child: string }) => {
+  list.action(async (options: CliFormatOptions & { child?: string }) => {
     const session = context.createSession();
-    const child = await session.resolveChild(options.child);
-    const client = await session.forChild(child);
+    const { child, client } = await createChildApiClient(
+      session,
+      options.child,
+    );
     const data = await client.listLessons();
 
-    writeChildScopedOutput(context, options.format, child, data);
+    writeOptionalChildScopedOutput(context, options.format, child, data);
   });
 
-  get.requiredOption("--child <id-or-login>", "Child account id or login");
   get.requiredOption("--id <id>", "Lesson id");
   get.action(
-    async (options: CliFormatOptions & { child: string; id: string }) => {
+    async (options: CliFormatOptions & { child?: string; id: string }) => {
       const session = context.createSession();
-      const child = await session.resolveChild(options.child);
-      const client = await session.forChild(child);
+      const { child, client } = await createChildApiClient(
+        session,
+        options.child,
+      );
       const data = await client.getLesson(options.id);
 
-      writeChildScopedOutput(context, options.format, child, data);
+      writeOptionalChildScopedOutput(context, options.format, child, data);
     },
   );
 
-  plannedList.requiredOption(
-    "--child <id-or-login>",
-    "Child account id or login",
-  );
-  plannedList.action(async (options: CliFormatOptions & { child: string }) => {
+  plannedList.action(async (options: CliFormatOptions & { child?: string }) => {
     const session = context.createSession();
-    const child = await session.resolveChild(options.child);
-    const client = await session.forChild(child);
+    const { child, client } = await createChildApiClient(
+      session,
+      options.child,
+    );
     const data = await client.listPlannedLessons();
 
-    writeChildScopedOutput(context, options.format, child, data);
+    writeOptionalChildScopedOutput(context, options.format, child, data);
   });
 
-  plannedGet.requiredOption(
-    "--child <id-or-login>",
-    "Child account id or login",
-  );
   plannedGet.requiredOption("--id <id>", "Planned lesson id");
   plannedGet.action(
-    async (options: CliFormatOptions & { child: string; id: string }) => {
+    async (options: CliFormatOptions & { child?: string; id: string }) => {
       const session = context.createSession();
-      const child = await session.resolveChild(options.child);
-      const client = await session.forChild(child);
+      const { child, client } = await createChildApiClient(
+        session,
+        options.child,
+      );
       const data = await client.getPlannedLesson(options.id);
 
-      writeChildScopedOutput(context, options.format, child, data);
+      writeOptionalChildScopedOutput(context, options.format, child, data);
     },
   );
 
-  plannedAttachment.requiredOption(
-    "--child <id-or-login>",
-    "Child account id or login",
-  );
   plannedAttachment.requiredOption("--id <id>", "Attachment id");
   plannedAttachment.requiredOption(
     "--output <path>",
@@ -122,58 +134,59 @@ export function createLessonsCommand(context: CliContext): Command {
   plannedAttachment.action(
     async (
       options: CliFormatOptions & {
-        child: string;
+        child?: string;
         id: string;
         output: string;
       },
     ) => {
       const session = context.createSession();
-      const child = await session.resolveChild(options.child);
-      const client = await session.forChild(child);
+      const { child, client } = await createChildApiClient(
+        session,
+        options.child,
+      );
       const file = await client.getPlannedLessonAttachment(options.id);
       const data = writeBinaryDownload(context, options.output, file);
 
-      writeChildScopedOutput(
+      writeOptionalChildScopedOutput(
         context,
         options.format,
         child,
         data,
-        (summary) => [
-          { title: "Child", value: summary },
-          ...createSingleDataSection("Saved File", data),
-        ],
+        (summary) =>
+          summary
+            ? [
+                { title: "Child", value: summary },
+                ...createSingleDataSection("Saved File", data),
+              ]
+            : createSingleDataSection("Saved File", data),
       );
     },
   );
 
-  realizationsList.requiredOption(
-    "--child <id-or-login>",
-    "Child account id or login",
-  );
   realizationsList.action(
-    async (options: CliFormatOptions & { child: string }) => {
+    async (options: CliFormatOptions & { child?: string }) => {
       const session = context.createSession();
-      const child = await session.resolveChild(options.child);
-      const client = await session.forChild(child);
+      const { child, client } = await createChildApiClient(
+        session,
+        options.child,
+      );
       const data = await client.listRealizations();
 
-      writeChildScopedOutput(context, options.format, child, data);
+      writeOptionalChildScopedOutput(context, options.format, child, data);
     },
   );
 
-  realizationsGet.requiredOption(
-    "--child <id-or-login>",
-    "Child account id or login",
-  );
   realizationsGet.requiredOption("--id <id>", "Realization id");
   realizationsGet.action(
-    async (options: CliFormatOptions & { child: string; id: string }) => {
+    async (options: CliFormatOptions & { child?: string; id: string }) => {
       const session = context.createSession();
-      const child = await session.resolveChild(options.child);
-      const client = await session.forChild(child);
+      const { child, client } = await createChildApiClient(
+        session,
+        options.child,
+      );
       const data = await client.getRealization(options.id);
 
-      writeChildScopedOutput(context, options.format, child, data);
+      writeOptionalChildScopedOutput(context, options.format, child, data);
     },
   );
 

--- a/src/cli/commands/luckyNumber.ts
+++ b/src/cli/commands/luckyNumber.ts
@@ -3,9 +3,11 @@ import { Command } from "commander";
 import type { CliContext } from "./common.js";
 import {
   addFormatOption,
+  addChildOption,
   configureCommand,
+  createChildApiClient,
   type CliFormatOptions,
-  writeChildScopedOutput,
+  writeOptionalChildScopedOutput,
 } from "./common.js";
 
 export function createLuckyNumberCommand(context: CliContext): Command {
@@ -14,20 +16,23 @@ export function createLuckyNumberCommand(context: CliContext): Command {
     context,
   );
   const get = configureCommand(
-    addFormatOption(new Command("get").description("Get the lucky number")),
+    addChildOption(
+      addFormatOption(new Command("get").description("Get the lucky number")),
+    ),
     context,
   );
 
-  get.requiredOption("--child <id-or-login>", "Child account id or login");
   get.option("--for-day <YYYY-MM-DD>", "Request the lucky number for a day");
   get.action(
-    async (options: CliFormatOptions & { child: string; forDay?: string }) => {
+    async (options: CliFormatOptions & { child?: string; forDay?: string }) => {
       const session = context.createSession();
-      const child = await session.resolveChild(options.child);
-      const client = await session.forChild(child);
+      const { child, client } = await createChildApiClient(
+        session,
+        options.child,
+      );
       const data = await client.getLuckyNumber(options.forDay);
 
-      writeChildScopedOutput(context, options.format, child, data);
+      writeOptionalChildScopedOutput(context, options.format, child, data);
     },
   );
 

--- a/src/cli/commands/me.ts
+++ b/src/cli/commands/me.ts
@@ -3,25 +3,30 @@ import { Command } from "commander";
 import type { CliContext } from "./common.js";
 import {
   addFormatOption,
+  addChildOption,
   configureCommand,
+  createChildApiClient,
   type CliFormatOptions,
-  writeChildScopedOutput,
+  writeOptionalChildScopedOutput,
 } from "./common.js";
 
 export function createMeCommand(context: CliContext): Command {
   const me = configureCommand(
-    addFormatOption(new Command("me").description("Get child profile data")),
+    addChildOption(
+      addFormatOption(new Command("me").description("Get child profile data")),
+    ),
     context,
   );
 
-  me.requiredOption("--child <id-or-login>", "Child account id or login");
-  me.action(async (options: CliFormatOptions & { child: string }) => {
+  me.action(async (options: CliFormatOptions & { child?: string }) => {
     const session = context.createSession();
-    const child = await session.resolveChild(options.child);
-    const client = await session.forChild(child);
+    const { child, client } = await createChildApiClient(
+      session,
+      options.child,
+    );
     const data = await client.getMe();
 
-    writeChildScopedOutput(context, options.format, child, data);
+    writeOptionalChildScopedOutput(context, options.format, child, data);
   });
 
   return me;

--- a/src/cli/commands/messages.ts
+++ b/src/cli/commands/messages.ts
@@ -1,13 +1,22 @@
 import { Command, InvalidArgumentError } from "commander";
 
-import type { ChildAccount, LibrusSession } from "../../sdk/index.js";
+import {
+  LibrusSdkError,
+  type ChildAccount,
+  type LibrusSession,
+} from "../../sdk/index.js";
 
 import type { CliContext } from "./common.js";
 import {
   addFormatOption,
+  addChildOption,
   configureCommand,
+  createChildApiClient,
+  getSessionApiBackend,
+  resolveApiV3ChildSelector,
   type CliFormatOptions,
   writeChildScopedOutput,
+  writeOptionalChildScopedOutput,
 } from "./common.js";
 
 type MessageBackendName = "api3" | "wiadomosci";
@@ -22,55 +31,68 @@ export function createMessagesCommand(context: CliContext): Command {
     context,
   );
   const list = configureCommand(
-    addFormatOption(
-      new Command("list").description("List messages for a child"),
+    addChildOption(
+      addFormatOption(
+        new Command("list").description("List messages for a child"),
+      ),
     ),
     context,
   );
   const bffList = configureCommand(
-    addFormatOption(
-      new Command("bff-list").description(
-        "List BFF inbox messages for a child",
+    addChildOption(
+      addFormatOption(
+        new Command("bff-list").description(
+          "List BFF inbox messages for a child",
+        ),
       ),
     ),
     context,
   );
   const get = configureCommand(
-    addFormatOption(new Command("get").description("Get a message by id")),
+    addChildOption(
+      addFormatOption(new Command("get").description("Get a message by id")),
+    ),
     context,
   );
   const unread = configureCommand(
-    addFormatOption(
-      new Command("unread").description("List unread messages for a child"),
+    addChildOption(
+      addFormatOption(
+        new Command("unread").description("List unread messages for a child"),
+      ),
     ),
     context,
   );
   const wiadomosciList = configureCommand(
-    addFormatOption(
-      new Command("wiadomosci-list").description(
-        "List messages through wiadomosci.librus.pl",
+    addChildOption(
+      addFormatOption(
+        new Command("wiadomosci-list").description(
+          "List messages through wiadomosci.librus.pl",
+        ),
       ),
     ),
     context,
   );
   const wiadomosciGet = configureCommand(
-    addFormatOption(
-      new Command("wiadomosci-get").description(
-        "Get a message through wiadomosci.librus.pl",
+    addChildOption(
+      addFormatOption(
+        new Command("wiadomosci-get").description(
+          "Get a message through wiadomosci.librus.pl",
+        ),
       ),
     ),
     context,
   );
   const wiadomosciUnread = configureCommand(
-    addFormatOption(
-      new Command("wiadomosci-unread").description(
-        "List unread messages through wiadomosci.librus.pl",
+    addChildOption(
+      addFormatOption(
+        new Command("wiadomosci-unread").description(
+          "List unread messages through wiadomosci.librus.pl",
+        ),
       ),
     ),
     context,
   );
 
-  list.requiredOption("--child <id-or-login>", "Child account id or login");
   list.option("--after-id <id>", "List messages after the given message id");
   list.option(
     "--backend <backend>",
@@ -80,30 +102,31 @@ export function createMessagesCommand(context: CliContext): Command {
   );
   list.action(
     async (
-      options: MessageBackendOptions & { afterId?: string; child: string },
+      options: MessageBackendOptions & { afterId?: string; child?: string },
     ) => {
       const session = context.createSession();
-      const child = await session.resolveChild(options.child);
-      const client = await createMessageClient(session, child, options.backend);
+      const { child, client } = await createMessageClient(
+        session,
+        options.child,
+        options.backend,
+      );
       const data = await client.listMessages(
         options.afterId ? { afterId: options.afterId } : {},
       );
 
-      writeChildScopedOutput(context, options.format, child, data);
+      writeOptionalChildScopedOutput(context, options.format, child, data);
     },
   );
 
-  bffList.requiredOption("--child <id-or-login>", "Child account id or login");
-  bffList.action(async (options: CliFormatOptions & { child: string }) => {
+  bffList.action(async (options: CliFormatOptions & { child?: string }) => {
     const session = context.createSession();
-    const child = await session.resolveChild(options.child);
+    const child = await resolvePortalChild(session, options.child);
     const client = await session.forChildBff(child);
     const data = await client.listMessages();
 
     writeChildScopedOutput(context, options.format, child, data);
   });
 
-  get.requiredOption("--child <id-or-login>", "Child account id or login");
   get.requiredOption("--id <id>", "Message id");
   get.option(
     "--backend <backend>",
@@ -112,44 +135,47 @@ export function createMessagesCommand(context: CliContext): Command {
     "api3",
   );
   get.action(
-    async (options: MessageBackendOptions & { child: string; id: string }) => {
+    async (options: MessageBackendOptions & { child?: string; id: string }) => {
       const session = context.createSession();
-      const child = await session.resolveChild(options.child);
-      const client = await createMessageClient(session, child, options.backend);
+      const { child, client } = await createMessageClient(
+        session,
+        options.child,
+        options.backend,
+      );
       const data = await client.getMessage(options.id);
 
-      writeChildScopedOutput(context, options.format, child, data);
+      writeOptionalChildScopedOutput(context, options.format, child, data);
     },
   );
 
-  unread.requiredOption("--child <id-or-login>", "Child account id or login");
   unread.option(
     "--backend <backend>",
     "Message backend: api3 or wiadomosci",
     parseMessageBackendName,
     "api3",
   );
-  unread.action(async (options: MessageBackendOptions & { child: string }) => {
+  unread.action(async (options: MessageBackendOptions & { child?: string }) => {
     const session = context.createSession();
-    const child = await session.resolveChild(options.child);
-    const client = await createMessageClient(session, child, options.backend);
+    const { child, client } = await createMessageClient(
+      session,
+      options.child,
+      options.backend,
+    );
     const data = await client.getUnreadMessages();
 
-    writeChildScopedOutput(context, options.format, child, data);
+    writeOptionalChildScopedOutput(context, options.format, child, data);
   });
 
-  wiadomosciList.requiredOption(
-    "--child <id-or-login>",
-    "Child account id or login",
-  );
   wiadomosciList.option(
     "--after-id <id>",
     "List messages after the given message id",
   );
   wiadomosciList.action(
-    async (options: CliFormatOptions & { afterId?: string; child: string }) => {
+    async (
+      options: CliFormatOptions & { afterId?: string; child?: string },
+    ) => {
       const session = context.createSession();
-      const child = await session.resolveChild(options.child);
+      const child = await resolvePortalChild(session, options.child);
       const client = await session.forChildWiadomosci(child);
       const data = await client.listMessages(
         options.afterId ? { afterId: options.afterId } : {},
@@ -159,15 +185,11 @@ export function createMessagesCommand(context: CliContext): Command {
     },
   );
 
-  wiadomosciGet.requiredOption(
-    "--child <id-or-login>",
-    "Child account id or login",
-  );
   wiadomosciGet.requiredOption("--id <id>", "Message id");
   wiadomosciGet.action(
-    async (options: CliFormatOptions & { child: string; id: string }) => {
+    async (options: CliFormatOptions & { child?: string; id: string }) => {
       const session = context.createSession();
-      const child = await session.resolveChild(options.child);
+      const child = await resolvePortalChild(session, options.child);
       const client = await session.forChildWiadomosci(child);
       const data = await client.getMessage(options.id);
 
@@ -175,14 +197,10 @@ export function createMessagesCommand(context: CliContext): Command {
     },
   );
 
-  wiadomosciUnread.requiredOption(
-    "--child <id-or-login>",
-    "Child account id or login",
-  );
   wiadomosciUnread.action(
-    async (options: CliFormatOptions & { child: string }) => {
+    async (options: CliFormatOptions & { child?: string }) => {
       const session = context.createSession();
-      const child = await session.resolveChild(options.child);
+      const child = await resolvePortalChild(session, options.child);
       const client = await session.forChildWiadomosci(child);
       const data = await client.getUnreadMessages();
 
@@ -211,10 +229,46 @@ function parseMessageBackendName(value: string): MessageBackendName {
 
 async function createMessageClient(
   session: LibrusSession,
-  child: ChildAccount,
+  childSelector: string | undefined,
   backend: MessageBackendName,
-): ReturnType<LibrusSession["forChild"]> {
-  return backend === "wiadomosci"
-    ? session.forChildWiadomosci(child)
-    : session.forChild(child);
+): Promise<{
+  child?: ChildAccount;
+  client: Awaited<ReturnType<LibrusSession["forChild"]>>;
+}> {
+  if (backend === "api3") {
+    return createChildApiClient(session, childSelector);
+  }
+
+  const child = await resolvePortalChild(session, childSelector);
+
+  return {
+    child,
+    client: await session.forChildWiadomosci(child),
+  };
+}
+
+async function resolvePortalChild(
+  session: LibrusSession,
+  childSelector?: string,
+): Promise<ChildAccount> {
+  const apiBackend = getSessionApiBackend(session);
+
+  if (apiBackend === "gateway_api_20") {
+    throw new LibrusSdkError(
+      "UNSUPPORTED_BACKEND",
+      "This command requires api_v3 and is not available when using gateway_api_20.",
+      { apiBackend },
+    );
+  }
+
+  const resolvedChildSelector = resolveApiV3ChildSelector(childSelector);
+
+  if (!resolvedChildSelector) {
+    throw new LibrusSdkError(
+      "CHILD_REQUIRED",
+      "Child account id or login is required for api_v3. Pass --child <id-or-login> or set LIBRUS_CHILD.",
+    );
+  }
+
+  return session.resolveChild(resolvedChildSelector);
 }

--- a/src/cli/commands/notes.ts
+++ b/src/cli/commands/notes.ts
@@ -3,9 +3,11 @@ import { Command } from "commander";
 import type { CliContext } from "./common.js";
 import {
   addFormatOption,
+  addChildOption,
   configureCommand,
+  createChildApiClient,
   type CliFormatOptions,
-  writeChildScopedOutput,
+  writeOptionalChildScopedOutput,
 } from "./common.js";
 
 export function createNotesCommand(context: CliContext): Command {
@@ -14,34 +16,42 @@ export function createNotesCommand(context: CliContext): Command {
     context,
   );
   const list = configureCommand(
-    addFormatOption(new Command("list").description("List notes for a child")),
+    addChildOption(
+      addFormatOption(
+        new Command("list").description("List notes for a child"),
+      ),
+    ),
     context,
   );
   const get = configureCommand(
-    addFormatOption(new Command("get").description("Get a note by id")),
+    addChildOption(
+      addFormatOption(new Command("get").description("Get a note by id")),
+    ),
     context,
   );
 
-  list.requiredOption("--child <id-or-login>", "Child account id or login");
-  list.action(async (options: CliFormatOptions & { child: string }) => {
+  list.action(async (options: CliFormatOptions & { child?: string }) => {
     const session = context.createSession();
-    const child = await session.resolveChild(options.child);
-    const client = await session.forChild(child);
+    const { child, client } = await createChildApiClient(
+      session,
+      options.child,
+    );
     const data = await client.listNotes();
 
-    writeChildScopedOutput(context, options.format, child, data);
+    writeOptionalChildScopedOutput(context, options.format, child, data);
   });
 
-  get.requiredOption("--child <id-or-login>", "Child account id or login");
   get.requiredOption("--id <id>", "Note id");
   get.action(
-    async (options: CliFormatOptions & { child: string; id: string }) => {
+    async (options: CliFormatOptions & { child?: string; id: string }) => {
       const session = context.createSession();
-      const child = await session.resolveChild(options.child);
-      const client = await session.forChild(child);
+      const { child, client } = await createChildApiClient(
+        session,
+        options.child,
+      );
       const data = await client.getNote(options.id);
 
-      writeChildScopedOutput(context, options.format, child, data);
+      writeOptionalChildScopedOutput(context, options.format, child, data);
     },
   );
 

--- a/src/cli/commands/notifications.ts
+++ b/src/cli/commands/notifications.ts
@@ -3,9 +3,11 @@ import { Command } from "commander";
 import type { CliContext } from "./common.js";
 import {
   addFormatOption,
+  addChildOption,
   configureCommand,
+  createChildApiClient,
   type CliFormatOptions,
-  writeChildScopedOutput,
+  writeOptionalChildScopedOutput,
 } from "./common.js";
 
 export function createNotificationsCommand(context: CliContext): Command {
@@ -14,42 +16,45 @@ export function createNotificationsCommand(context: CliContext): Command {
     context,
   );
   const center = configureCommand(
-    addFormatOption(
-      new Command("center").description("Get notification center settings"),
+    addChildOption(
+      addFormatOption(
+        new Command("center").description("Get notification center settings"),
+      ),
     ),
     context,
   );
   const pushConfigurations = configureCommand(
-    addFormatOption(
-      new Command("push-configurations").description(
-        "Get push notification configuration",
+    addChildOption(
+      addFormatOption(
+        new Command("push-configurations").description(
+          "Get push notification configuration",
+        ),
       ),
     ),
     context,
   );
 
-  center.requiredOption("--child <id-or-login>", "Child account id or login");
-  center.action(async (options: CliFormatOptions & { child: string }) => {
+  center.action(async (options: CliFormatOptions & { child?: string }) => {
     const session = context.createSession();
-    const child = await session.resolveChild(options.child);
-    const client = await session.forChild(child);
+    const { child, client } = await createChildApiClient(
+      session,
+      options.child,
+    );
     const data = await client.getNotificationCenter();
 
-    writeChildScopedOutput(context, options.format, child, data);
+    writeOptionalChildScopedOutput(context, options.format, child, data);
   });
 
-  pushConfigurations.requiredOption(
-    "--child <id-or-login>",
-    "Child account id or login",
-  );
   pushConfigurations.action(
-    async (options: CliFormatOptions & { child: string }) => {
+    async (options: CliFormatOptions & { child?: string }) => {
       const session = context.createSession();
-      const child = await session.resolveChild(options.child);
-      const client = await session.forChild(child);
+      const { child, client } = await createChildApiClient(
+        session,
+        options.child,
+      );
       const data = await client.getPushConfigurations();
 
-      writeChildScopedOutput(context, options.format, child, data);
+      writeOptionalChildScopedOutput(context, options.format, child, data);
     },
   );
 

--- a/src/cli/commands/timetable.ts
+++ b/src/cli/commands/timetable.ts
@@ -3,9 +3,11 @@ import { Command } from "commander";
 import type { CliContext } from "./common.js";
 import {
   addFormatOption,
+  addChildOption,
   configureCommand,
+  createChildApiClient,
   type CliFormatOptions,
-  writeChildScopedOutput,
+  writeOptionalChildScopedOutput,
 } from "./common.js";
 
 export function createTimetableCommand(context: CliContext): Command {
@@ -14,62 +16,71 @@ export function createTimetableCommand(context: CliContext): Command {
     context,
   );
   const week = configureCommand(
-    addFormatOption(
-      new Command("week").description("Get timetable entries for a week"),
+    addChildOption(
+      addFormatOption(
+        new Command("week").description("Get timetable entries for a week"),
+      ),
     ),
     context,
   );
   const day = configureCommand(
-    addFormatOption(
-      new Command("day").description("Get timetable entries for a day"),
+    addChildOption(
+      addFormatOption(
+        new Command("day").description("Get timetable entries for a day"),
+      ),
     ),
     context,
   );
   const entry = configureCommand(
-    addFormatOption(
-      new Command("entry").description("Get a timetable entry by id"),
+    addChildOption(
+      addFormatOption(
+        new Command("entry").description("Get a timetable entry by id"),
+      ),
     ),
     context,
   );
 
-  week.requiredOption("--child <id-or-login>", "Child account id or login");
   week.requiredOption("--week-start <YYYY-MM-DD>", "Week start date");
   week.action(
     async (
-      options: CliFormatOptions & { child: string; weekStart: string },
+      options: CliFormatOptions & { child?: string; weekStart: string },
     ) => {
       const session = context.createSession();
-      const child = await session.resolveChild(options.child);
-      const client = await session.forChild(child);
+      const { child, client } = await createChildApiClient(
+        session,
+        options.child,
+      );
       const data = await client.getTimetableWeek(options.weekStart);
 
-      writeChildScopedOutput(context, options.format, child, data);
+      writeOptionalChildScopedOutput(context, options.format, child, data);
     },
   );
 
-  day.requiredOption("--child <id-or-login>", "Child account id or login");
   day.requiredOption("--day <YYYY-MM-DD>", "Day");
   day.action(
-    async (options: CliFormatOptions & { child: string; day: string }) => {
+    async (options: CliFormatOptions & { child?: string; day: string }) => {
       const session = context.createSession();
-      const child = await session.resolveChild(options.child);
-      const client = await session.forChild(child);
+      const { child, client } = await createChildApiClient(
+        session,
+        options.child,
+      );
       const data = await client.getTimetableDay(options.day);
 
-      writeChildScopedOutput(context, options.format, child, data);
+      writeOptionalChildScopedOutput(context, options.format, child, data);
     },
   );
 
-  entry.requiredOption("--child <id-or-login>", "Child account id or login");
   entry.requiredOption("--id <id>", "Timetable entry id");
   entry.action(
-    async (options: CliFormatOptions & { child: string; id: string }) => {
+    async (options: CliFormatOptions & { child?: string; id: string }) => {
       const session = context.createSession();
-      const child = await session.resolveChild(options.child);
-      const client = await session.forChild(child);
+      const { child, client } = await createChildApiClient(
+        session,
+        options.child,
+      );
       const data = await client.getTimetableEntry(options.id);
 
-      writeChildScopedOutput(context, options.format, child, data);
+      writeOptionalChildScopedOutput(context, options.format, child, data);
     },
   );
 

--- a/src/cli/deprecatedMain.ts
+++ b/src/cli/deprecatedMain.ts
@@ -19,6 +19,7 @@ export async function runDeprecatedLibrusCli(
   return runCli(argv, context);
 }
 
+/* v8 ignore next -- covered by packaged CLI smoke tests instead of unit import. */
 if (isCliEntryPoint(process.argv, import.meta.url)) {
   loadCliEnvironment();
   const exitCode = await runDeprecatedLibrusCli(

--- a/src/sdk/LibrusSession.ts
+++ b/src/sdk/LibrusSession.ts
@@ -4,6 +4,10 @@ import {
   type PortalClientOptions,
 } from "./portal/PortalClient.js";
 import {
+  GatewayApi20AuthClient,
+  type GatewayApi20AuthClientOptions,
+} from "./synergia/GatewayApi20AuthClient.js";
+import {
   SynergiaApiClient,
   type SynergiaApiClientOptions,
 } from "./synergia/SynergiaApiClient.js";
@@ -15,25 +19,44 @@ import {
   LibrusConfigurationError,
   LibrusSdkError,
   type ChildAccount,
+  type GatewayCredentials,
   type PortalCredentials,
   type PortalMe,
   type SynergiaAccountsResponse,
+  type SynergiaCredentials,
 } from "./models/index.js";
 import {
   parseRequestTimeoutMsFromEnv,
   validateOptionalRequestTimeoutMs,
 } from "./requestTimeout.js";
+import { emitDeprecationWarningOnce } from "./deprecationWarnings.js";
 
 type PortalCredentialEnvName =
   | "LIBRUS_EMAIL"
   | "LIBRUS_PASSWORD"
   | "LIBRUS_PORTAL_EMAIL"
   | "LIBRUS_PORTAL_PASSWORD";
+type GatewayCredentialEnvName =
+  | "LIBRUS_GATEWAY_LOGIN"
+  | "LIBRUS_GATEWAY_PASSWORD"
+  | "SYNERGIA_ID"
+  | "SYNERGIA_PASSWORD";
+type ApiBackendEnvValue = "api_v3" | "gateway_api_20";
+type AuthModeEnvValue = "portal" | "synergia";
+
+export type LibrusApiBackend = ApiBackendEnvValue;
+export type LibrusAuthMode = AuthModeEnvValue;
 
 interface PortalCredentialEnvField {
   label: string;
   primary: PortalCredentialEnvName;
   fallback: PortalCredentialEnvName;
+}
+
+interface GatewayCredentialEnvField {
+  label: string;
+  primary: GatewayCredentialEnvName;
+  alias: GatewayCredentialEnvName;
 }
 
 const PORTAL_EMAIL_ENV: PortalCredentialEnvField = {
@@ -48,10 +71,31 @@ const PORTAL_PASSWORD_ENV: PortalCredentialEnvField = {
   fallback: "LIBRUS_PASSWORD",
 };
 
+const GATEWAY_LOGIN_ENV: GatewayCredentialEnvField = {
+  label: "Login",
+  primary: "LIBRUS_GATEWAY_LOGIN",
+  alias: "SYNERGIA_ID",
+};
+
+const GATEWAY_PASSWORD_ENV: GatewayCredentialEnvField = {
+  label: "Password",
+  primary: "LIBRUS_GATEWAY_PASSWORD",
+  alias: "SYNERGIA_PASSWORD",
+};
+
 export interface LibrusSessionOptions {
-  credentials: PortalCredentials;
+  credentials: PortalCredentials | GatewayCredentials | SynergiaCredentials;
+  apiBackend?: LibrusApiBackend;
+  /** @deprecated Use apiBackend instead. */
+  authMode?: LibrusAuthMode;
   portalClient?: PortalClient;
   portalClientOptions?: PortalClientOptions;
+  gatewayApi20AuthClient?: GatewayApi20AuthClient;
+  gatewayApi20AuthClientOptions?: GatewayApi20AuthClientOptions;
+  /** @deprecated Use gatewayApi20AuthClient instead. */
+  directSynergiaAuthClient?: GatewayApi20AuthClient;
+  /** @deprecated Use gatewayApi20AuthClientOptions instead. */
+  directSynergiaAuthClientOptions?: GatewayApi20AuthClientOptions;
   bffClientOptions?: BffApiClientOptions;
   synergiaClientOptions?: SynergiaApiClientOptions;
   wiadomosciClientOptions?: Omit<
@@ -62,8 +106,11 @@ export interface LibrusSessionOptions {
 }
 
 export class LibrusSession {
-  private readonly credentials: PortalCredentials;
-  private readonly portalClient: PortalClient;
+  private readonly apiBackend: LibrusApiBackend;
+  private readonly portalCredentials: PortalCredentials | undefined;
+  private readonly gatewayCredentials: GatewayCredentials | undefined;
+  private readonly portalClient: PortalClient | undefined;
+  private readonly gatewayApi20AuthClient: GatewayApi20AuthClient | undefined;
   private readonly bffClientOptions: BffApiClientOptions | undefined;
   private readonly synergiaClientOptions: SynergiaApiClientOptions | undefined;
   private readonly wiadomosciClientOptions:
@@ -75,100 +122,175 @@ export class LibrusSession {
   private accountsCache?: SynergiaAccountsResponse;
 
   constructor(options: LibrusSessionOptions) {
+    if (options.authMode !== undefined) {
+      emitDeprecationWarningOnce(
+        "LIBRUS_AUTH_MODE_OPTION_DEPRECATED",
+        "LibrusSessionOptions.authMode is deprecated; use apiBackend instead.",
+      );
+    }
+
+    if (options.directSynergiaAuthClient !== undefined) {
+      emitDeprecationWarningOnce(
+        "LIBRUS_DIRECT_SYNERGIA_AUTH_CLIENT_DEPRECATED",
+        "LibrusSessionOptions.directSynergiaAuthClient is deprecated; use gatewayApi20AuthClient instead.",
+      );
+    }
+
+    if (options.directSynergiaAuthClientOptions !== undefined) {
+      emitDeprecationWarningOnce(
+        "LIBRUS_DIRECT_SYNERGIA_AUTH_CLIENT_OPTIONS_DEPRECATED",
+        "LibrusSessionOptions.directSynergiaAuthClientOptions is deprecated; use gatewayApi20AuthClientOptions instead.",
+      );
+    }
+
+    this.apiBackend =
+      options.apiBackend ??
+      mapAuthModeToApiBackend(options.authMode) ??
+      "api_v3";
     const requestTimeoutMs = validateOptionalRequestTimeoutMs(
       options.requestTimeoutMs,
     );
-    const portalClientOptions =
-      options.portalClientOptions?.requestTimeoutMs !== undefined ||
-      requestTimeoutMs === undefined
-        ? options.portalClientOptions
-        : options.portalClientOptions
-          ? {
-              ...options.portalClientOptions,
-              requestTimeoutMs,
-            }
-          : { requestTimeoutMs };
-    const synergiaClientOptions =
-      options.synergiaClientOptions?.requestTimeoutMs !== undefined ||
-      requestTimeoutMs === undefined
-        ? options.synergiaClientOptions
-        : options.synergiaClientOptions
-          ? {
-              ...options.synergiaClientOptions,
-              requestTimeoutMs,
-            }
-          : { requestTimeoutMs };
-    const bffClientOptions =
-      options.bffClientOptions?.requestTimeoutMs !== undefined ||
-      requestTimeoutMs === undefined
-        ? options.bffClientOptions
-        : options.bffClientOptions
-          ? {
-              ...options.bffClientOptions,
-              requestTimeoutMs,
-            }
-          : { requestTimeoutMs };
-    const wiadomosciClientOptions =
-      options.wiadomosciClientOptions?.requestTimeoutMs !== undefined ||
-      requestTimeoutMs === undefined
-        ? options.wiadomosciClientOptions
-        : options.wiadomosciClientOptions
-          ? {
-              ...options.wiadomosciClientOptions,
-              requestTimeoutMs,
-            }
-          : { requestTimeoutMs };
+    const portalClientOptions = applyRequestTimeout(
+      options.portalClientOptions,
+      requestTimeoutMs,
+    );
+    const synergiaClientOptions = applyRequestTimeout(
+      options.synergiaClientOptions,
+      requestTimeoutMs,
+    );
+    const bffClientOptions = applyRequestTimeout(
+      options.bffClientOptions,
+      requestTimeoutMs,
+    );
+    const wiadomosciClientOptions = applyRequestTimeout(
+      options.wiadomosciClientOptions,
+      requestTimeoutMs,
+    );
+    const gatewayApi20AuthClientOptions = applyRequestTimeout(
+      options.gatewayApi20AuthClientOptions ??
+        options.directSynergiaAuthClientOptions,
+      requestTimeoutMs,
+    );
 
-    this.credentials = options.credentials;
-    this.portalClient =
-      options.portalClient ?? new PortalClient(portalClientOptions);
+    if (this.apiBackend === "api_v3") {
+      this.portalCredentials = normalizePortalCredentials(options.credentials);
+      this.portalClient =
+        options.portalClient ?? new PortalClient(portalClientOptions);
+    } else {
+      this.gatewayCredentials = normalizeGatewayCredentials(
+        options.credentials,
+      );
+      this.gatewayApi20AuthClient =
+        options.gatewayApi20AuthClient ??
+        options.directSynergiaAuthClient ??
+        new GatewayApi20AuthClient(gatewayApi20AuthClientOptions);
+    }
+
     this.bffClientOptions = bffClientOptions;
     this.synergiaClientOptions = synergiaClientOptions;
     this.wiadomosciClientOptions = wiadomosciClientOptions;
   }
 
   static fromEnv(env: NodeJS.ProcessEnv = process.env): LibrusSession {
-    const email = resolvePortalCredentialEnv(env, PORTAL_EMAIL_ENV);
-    const password = resolvePortalCredentialEnv(env, PORTAL_PASSWORD_ENV);
-
-    if (!email || !password) {
-      throw new LibrusConfigurationError(
-        buildMissingPortalCredentialsMessage(env),
-      );
-    }
-
+    const apiBackend = resolveApiBackend(env);
     const requestTimeoutMs = parseRequestTimeoutMsFromEnv(
       env.LIBRUS_TIMEOUT_MS,
     );
-    const sessionOptions: LibrusSessionOptions = {
-      credentials: { email, password },
-    };
+    const options = requestTimeoutMs === undefined ? {} : { requestTimeoutMs };
 
-    if (requestTimeoutMs !== undefined) {
-      sessionOptions.requestTimeoutMs = requestTimeoutMs;
+    if (apiBackend === "gateway_api_20") {
+      return LibrusSession.fromGatewayCredentials(
+        resolveGatewayCredentialsFromEnv(env),
+        options,
+      );
     }
 
-    return new LibrusSession(sessionOptions);
+    return new LibrusSession({
+      ...options,
+      apiBackend: "api_v3",
+      credentials: resolvePortalCredentialsFromEnv(env),
+    });
+  }
+
+  static fromGatewayCredentials(
+    credentials: GatewayCredentials,
+    options: Omit<
+      LibrusSessionOptions,
+      "apiBackend" | "authMode" | "credentials"
+    > = {},
+  ): LibrusSession {
+    return new LibrusSession({
+      ...options,
+      apiBackend: "gateway_api_20",
+      credentials,
+    });
+  }
+
+  /** @deprecated Use fromGatewayCredentials instead. */
+  static fromSynergiaCredentials(
+    credentials: SynergiaCredentials,
+    options: Omit<
+      LibrusSessionOptions,
+      "apiBackend" | "authMode" | "credentials"
+    > = {},
+  ): LibrusSession {
+    emitDeprecationWarningOnce(
+      "LIBRUS_FROM_SYNERGIA_CREDENTIALS_DEPRECATED",
+      "LibrusSession.fromSynergiaCredentials() is deprecated; use fromGatewayCredentials() instead.",
+    );
+
+    return LibrusSession.fromGatewayCredentials(
+      {
+        login: credentials.id,
+        password: credentials.password,
+      },
+      options,
+    );
+  }
+
+  getApiBackend(): LibrusApiBackend {
+    return this.apiBackend;
+  }
+
+  /** @deprecated Use getApiBackend instead. */
+  getAuthMode(): LibrusAuthMode {
+    emitDeprecationWarningOnce(
+      "LIBRUS_GET_AUTH_MODE_DEPRECATED",
+      "LibrusSession.getAuthMode() is deprecated; use getApiBackend() instead.",
+    );
+
+    return mapApiBackendToAuthMode(this.apiBackend);
   }
 
   async login(): Promise<void> {
-    if (this.portalClient.isLoggedIn()) {
+    if (this.apiBackend === "gateway_api_20") {
+      await this.getGatewayApi20AuthClient().login(
+        this.getGatewayCredentials(),
+      );
       return;
     }
 
-    await this.portalClient.login(this.credentials);
+    const portalClient = this.getPortalClient();
+
+    if (portalClient.isLoggedIn()) {
+      return;
+    }
+
+    await portalClient.login(this.getPortalCredentials());
   }
 
   async getPortalMe(): Promise<PortalMe> {
+    this.assertApiV3Backend("getPortalMe");
     await this.login();
-    return this.portalClient.getMe();
+    return this.getPortalClient().getMe();
   }
 
   async getSynergiaAccounts(): Promise<SynergiaAccountsResponse> {
+    this.assertApiV3Backend("getSynergiaAccounts");
     await this.login();
 
     if (!this.accountsCache) {
-      this.accountsCache = await this.portalClient.getSynergiaAccounts();
+      this.accountsCache = await this.getPortalClient().getSynergiaAccounts();
     }
 
     return this.accountsCache;
@@ -215,8 +337,30 @@ export class LibrusSession {
   }
 
   async forChild(
-    selectorOrChild: string | ChildAccount,
+    selectorOrChild?: string | ChildAccount,
   ): Promise<SynergiaApiClient> {
+    if (this.apiBackend === "gateway_api_20") {
+      if (selectorOrChild !== undefined) {
+        throw new LibrusSdkError(
+          "UNSUPPORTED_BACKEND",
+          "Child selection is not supported with gateway_api_20 because the gateway session is already scoped to one account.",
+          { apiBackend: this.apiBackend },
+        );
+      }
+
+      await this.login();
+      return this.getGatewayApi20AuthClient().createApiClient(
+        this.synergiaClientOptions,
+      );
+    }
+
+    if (selectorOrChild === undefined) {
+      throw new LibrusSdkError(
+        "CHILD_REQUIRED",
+        "Child account id, login, or ChildAccount is required for api_v3.",
+      );
+    }
+
     const child =
       typeof selectorOrChild === "string"
         ? await this.resolveChild(selectorOrChild)
@@ -228,6 +372,7 @@ export class LibrusSession {
   async forChildWiadomosci(
     selectorOrChild: string | ChildAccount,
   ): Promise<SynergiaApiClient> {
+    this.assertApiV3Backend("forChildWiadomosci");
     const child =
       typeof selectorOrChild === "string"
         ? await this.resolveChild(selectorOrChild)
@@ -235,7 +380,7 @@ export class LibrusSession {
     const messageBackend = new WiadomosciMessagesClient(child, {
       ...this.wiadomosciClientOptions,
       ensurePortalLogin: () => this.login(),
-      portalClient: this.portalClient,
+      portalClient: this.getPortalClient(),
     });
 
     return new SynergiaApiClient(child.accessToken, {
@@ -247,32 +392,258 @@ export class LibrusSession {
   async forChildBff(
     selectorOrChild: string | ChildAccount,
   ): Promise<BffApiClient> {
+    this.assertApiV3Backend("forChildBff");
     const child =
       typeof selectorOrChild === "string"
         ? await this.resolveChild(selectorOrChild)
         : selectorOrChild;
     return new BffApiClient(child.accessToken, this.bffClientOptions);
   }
+
+  private getPortalCredentials(): PortalCredentials {
+    const credentials = this.portalCredentials;
+
+    if (!credentials) {
+      throw new LibrusSdkError(
+        "UNSUPPORTED_BACKEND",
+        "This operation requires api_v3 portal credentials.",
+        { apiBackend: this.apiBackend },
+      );
+    }
+
+    return credentials;
+  }
+
+  private getGatewayCredentials(): GatewayCredentials {
+    const credentials = this.gatewayCredentials;
+
+    if (!credentials) {
+      throw new LibrusSdkError(
+        "UNSUPPORTED_BACKEND",
+        "This operation requires gateway_api_20 credentials.",
+        { apiBackend: this.apiBackend },
+      );
+    }
+
+    return credentials;
+  }
+
+  private getPortalClient(): PortalClient {
+    const portalClient = this.portalClient;
+
+    if (!portalClient) {
+      throw new LibrusSdkError(
+        "UNSUPPORTED_BACKEND",
+        "This operation requires the api_v3 portal backend.",
+        { apiBackend: this.apiBackend },
+      );
+    }
+
+    return portalClient;
+  }
+
+  private getGatewayApi20AuthClient(): GatewayApi20AuthClient {
+    if (!this.gatewayApi20AuthClient) {
+      throw new LibrusSdkError(
+        "UNSUPPORTED_BACKEND",
+        "This operation requires the gateway_api_20 backend.",
+        { apiBackend: this.apiBackend },
+      );
+    }
+
+    return this.gatewayApi20AuthClient;
+  }
+
+  private assertApiV3Backend(operation: string): void {
+    if (this.apiBackend === "api_v3") {
+      return;
+    }
+
+    throw new LibrusSdkError(
+      "UNSUPPORTED_BACKEND",
+      `${operation} requires api_v3 and is not available when using gateway_api_20.`,
+      { apiBackend: this.apiBackend },
+    );
+  }
+}
+
+function resolveApiBackend(env: NodeJS.ProcessEnv): ApiBackendEnvValue {
+  const rawApiBackend = env.LIBRUS_API_BACKEND;
+  const rawAuthMode = env.LIBRUS_AUTH_MODE;
+
+  if (rawAuthMode !== undefined) {
+    emitDeprecationWarningOnce(
+      "LIBRUS_AUTH_MODE_ENV_DEPRECATED",
+      "LIBRUS_AUTH_MODE is deprecated; use LIBRUS_API_BACKEND instead.",
+    );
+  }
+
+  if (rawApiBackend !== undefined) {
+    return parseApiBackendEnvValue(rawApiBackend);
+  }
+
+  if (rawAuthMode !== undefined) {
+    return parseAuthModeEnvValue(rawAuthMode);
+  }
+
+  if (hasCompletePortalCredentials(env)) {
+    return "api_v3";
+  }
+
+  if (hasCompleteGatewayCredentials(env)) {
+    return "gateway_api_20";
+  }
+
+  return "api_v3";
+}
+
+function parseApiBackendEnvValue(value: string): ApiBackendEnvValue {
+  if (value === "api_v3" || value === "gateway_api_20") {
+    return value;
+  }
+
+  throw new LibrusConfigurationError(
+    'Invalid LIBRUS_API_BACKEND. Expected "api_v3" or "gateway_api_20".',
+  );
+}
+
+function parseAuthModeEnvValue(value: string): ApiBackendEnvValue {
+  if (value === "portal") {
+    return "api_v3";
+  }
+
+  if (value === "synergia") {
+    return "gateway_api_20";
+  }
+
+  throw new LibrusConfigurationError(
+    'Invalid LIBRUS_AUTH_MODE. Expected "portal" or "synergia".',
+  );
+}
+
+function mapAuthModeToApiBackend(
+  authMode: LibrusAuthMode | undefined,
+): LibrusApiBackend | undefined {
+  if (authMode === "portal") {
+    return "api_v3";
+  }
+
+  if (authMode === "synergia") {
+    return "gateway_api_20";
+  }
+
+  return undefined;
+}
+
+function mapApiBackendToAuthMode(apiBackend: LibrusApiBackend): LibrusAuthMode {
+  return apiBackend === "api_v3" ? "portal" : "synergia";
+}
+
+function hasCompletePortalCredentials(env: NodeJS.ProcessEnv): boolean {
+  return Boolean(
+    resolvePortalCredentialEnv(env, PORTAL_EMAIL_ENV) &&
+    resolvePortalCredentialEnv(env, PORTAL_PASSWORD_ENV),
+  );
+}
+
+function hasCompleteGatewayCredentials(env: NodeJS.ProcessEnv): boolean {
+  return Boolean(
+    resolveGatewayCredentialEnv(env, GATEWAY_LOGIN_ENV) &&
+    resolveGatewayCredentialEnv(env, GATEWAY_PASSWORD_ENV),
+  );
+}
+
+function resolvePortalCredentialsFromEnv(
+  env: NodeJS.ProcessEnv,
+): PortalCredentials {
+  const email = resolvePortalCredentialEnv(env, PORTAL_EMAIL_ENV);
+  const password = resolvePortalCredentialEnv(env, PORTAL_PASSWORD_ENV);
+
+  if (!email || !password) {
+    throw new LibrusConfigurationError(
+      buildMissingPortalCredentialsMessage(env),
+    );
+  }
+
+  return { email, password };
+}
+
+function resolveGatewayCredentialsFromEnv(
+  env: NodeJS.ProcessEnv,
+): GatewayCredentials {
+  const login = resolveGatewayCredentialEnv(env, GATEWAY_LOGIN_ENV);
+  const password = resolveGatewayCredentialEnv(env, GATEWAY_PASSWORD_ENV);
+
+  if (!login || !password) {
+    throw new LibrusConfigurationError(
+      buildMissingGatewayCredentialsMessage(env),
+    );
+  }
+
+  return { login, password };
 }
 
 function resolvePortalCredentialEnv(
   env: NodeJS.ProcessEnv,
   field: PortalCredentialEnvField,
 ): string | undefined {
-  return env[field.primary] ?? env[field.fallback];
+  const primaryValue = env[field.primary];
+
+  if (primaryValue !== undefined) {
+    return primaryValue;
+  }
+
+  if (env[field.fallback] !== undefined) {
+    emitDeprecationWarningOnce(
+      `${field.fallback}_ENV_DEPRECATED`,
+      `${field.fallback} is deprecated; use ${field.primary} instead.`,
+    );
+  }
+
+  return env[field.fallback];
+}
+
+function resolveGatewayCredentialEnv(
+  env: NodeJS.ProcessEnv,
+  field: GatewayCredentialEnvField,
+): string | undefined {
+  const primaryValue = env[field.primary];
+
+  if (primaryValue !== undefined) {
+    return primaryValue;
+  }
+
+  if (env[field.alias] !== undefined) {
+    emitDeprecationWarningOnce(
+      `${field.alias}_ENV_DEPRECATED`,
+      `${field.alias} is deprecated; use ${field.primary} instead.`,
+    );
+  }
+
+  return env[field.alias];
 }
 
 function buildMissingPortalCredentialsMessage(env: NodeJS.ProcessEnv): string {
   return [
     "Missing portal credentials.",
-    describeCredentialEnvIssue(env, PORTAL_EMAIL_ENV),
-    describeCredentialEnvIssue(env, PORTAL_PASSWORD_ENV),
+    describePortalCredentialEnvIssue(env, PORTAL_EMAIL_ENV),
+    describePortalCredentialEnvIssue(env, PORTAL_PASSWORD_ENV),
   ]
     .filter((part): part is string => part !== undefined)
     .join(" ");
 }
 
-function describeCredentialEnvIssue(
+function buildMissingGatewayCredentialsMessage(env: NodeJS.ProcessEnv): string {
+  return [
+    "Missing gateway API 2.0 credentials.",
+    describeGatewayCredentialEnvIssue(env, GATEWAY_LOGIN_ENV),
+    describeGatewayCredentialEnvIssue(env, GATEWAY_PASSWORD_ENV),
+  ]
+    .filter((part): part is string => part !== undefined)
+    .join(" ");
+}
+
+function describePortalCredentialEnvIssue(
   env: NodeJS.ProcessEnv,
   field: PortalCredentialEnvField,
 ): string | undefined {
@@ -297,6 +668,73 @@ function describeCredentialEnvIssue(
   } is ${describeEnvValueState(fallbackValue)}.`;
 }
 
+function describeGatewayCredentialEnvIssue(
+  env: NodeJS.ProcessEnv,
+  field: GatewayCredentialEnvField,
+): string | undefined {
+  const resolvedValue = resolveGatewayCredentialEnv(env, field);
+
+  if (resolvedValue) {
+    return undefined;
+  }
+
+  return `${field.label}: ${field.primary} is ${describeEnvValueState(
+    env[field.primary],
+  )}.`;
+}
+
 function describeEnvValueState(value: string | undefined): "empty" | "unset" {
   return value === undefined ? "unset" : "empty";
+}
+
+function normalizePortalCredentials(
+  credentials: PortalCredentials | GatewayCredentials | SynergiaCredentials,
+): PortalCredentials {
+  if ("email" in credentials) {
+    return credentials;
+  }
+
+  throw new LibrusConfigurationError(
+    "api_v3 credentials require email and password.",
+  );
+}
+
+function normalizeGatewayCredentials(
+  credentials: PortalCredentials | GatewayCredentials | SynergiaCredentials,
+): GatewayCredentials {
+  if ("login" in credentials) {
+    return credentials;
+  }
+
+  if ("id" in credentials) {
+    emitDeprecationWarningOnce(
+      "LIBRUS_SYNERGIA_CREDENTIALS_ID_DEPRECATED",
+      'Gateway credentials with an "id" field are deprecated; use "login" instead.',
+    );
+
+    return {
+      login: credentials.id,
+      password: credentials.password,
+    };
+  }
+
+  throw new LibrusConfigurationError(
+    "gateway_api_20 credentials require login and password.",
+  );
+}
+
+function applyRequestTimeout<T extends { requestTimeoutMs?: number }>(
+  options: T | undefined,
+  requestTimeoutMs: number | undefined,
+): T | undefined {
+  if (
+    options?.requestTimeoutMs !== undefined ||
+    requestTimeoutMs === undefined
+  ) {
+    return options;
+  }
+
+  return options
+    ? { ...options, requestTimeoutMs }
+    : ({ requestTimeoutMs } as T);
 }

--- a/src/sdk/deprecationWarnings.ts
+++ b/src/sdk/deprecationWarnings.ts
@@ -1,0 +1,16 @@
+const emittedDeprecationWarningCodes = new Set<string>();
+
+export function emitDeprecationWarningOnce(
+  code: string,
+  message: string,
+): void {
+  if (emittedDeprecationWarningCodes.has(code)) {
+    return;
+  }
+
+  emittedDeprecationWarningCodes.add(code);
+  process.emitWarning(message, {
+    code,
+    type: "DeprecationWarning",
+  });
+}

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -1,7 +1,13 @@
 export { BffApiClient } from "./bff/BffApiClient.js";
-export { LibrusSession } from "./LibrusSession.js";
+export {
+  LibrusSession,
+  type LibrusApiBackend,
+  type LibrusAuthMode,
+} from "./LibrusSession.js";
 export { generateOpenApiDocument } from "./openapi.js";
 export { PortalClient } from "./portal/PortalClient.js";
+export { DirectSynergiaAuthClient } from "./synergia/DirectSynergiaAuthClient.js";
+export { GatewayApi20AuthClient } from "./synergia/GatewayApi20AuthClient.js";
 export { SynergiaApiClient } from "./synergia/SynergiaApiClient.js";
 export { WiadomosciMessagesClient } from "./wiadomosci/WiadomosciMessagesClient.js";
 export * from "./models/index.js";

--- a/src/sdk/models/credentials.ts
+++ b/src/sdk/models/credentials.ts
@@ -1,0 +1,9 @@
+export interface GatewayCredentials {
+  login: string;
+  password: string;
+}
+
+export interface SynergiaCredentials {
+  id: string;
+  password: string;
+}

--- a/src/sdk/models/index.ts
+++ b/src/sdk/models/index.ts
@@ -1,5 +1,6 @@
 export * from "./common.js";
 export * from "./bff.js";
+export * from "./credentials.js";
 export * from "./errors.js";
 export * from "./portal.js";
 export * from "./synergia.js";

--- a/src/sdk/synergia/DirectSynergiaAuthClient.ts
+++ b/src/sdk/synergia/DirectSynergiaAuthClient.ts
@@ -1,0 +1,21 @@
+import { emitDeprecationWarningOnce } from "../deprecationWarnings.js";
+
+import {
+  GatewayApi20AuthClient,
+  type GatewayApi20AuthClientOptions,
+} from "./GatewayApi20AuthClient.js";
+
+/** @deprecated Use GatewayApi20AuthClient instead. */
+export class DirectSynergiaAuthClient extends GatewayApi20AuthClient {
+  constructor(options: GatewayApi20AuthClientOptions = {}) {
+    emitDeprecationWarningOnce(
+      "LIBRUS_DIRECT_SYNERGIA_AUTH_CLIENT_CLASS_DEPRECATED",
+      "DirectSynergiaAuthClient is deprecated; use GatewayApi20AuthClient instead.",
+    );
+
+    super(options);
+  }
+}
+
+/** @deprecated Use GatewayApi20AuthClientOptions instead. */
+export type DirectSynergiaAuthClientOptions = GatewayApi20AuthClientOptions;

--- a/src/sdk/synergia/GatewayApi20AuthClient.ts
+++ b/src/sdk/synergia/GatewayApi20AuthClient.ts
@@ -1,0 +1,259 @@
+import { createSessionFetch } from "../auth/sessionFetch.js";
+import type { FetchLike } from "../models/common.js";
+import {
+  LibrusAuthenticationError,
+  type GatewayCredentials,
+  type SynergiaCredentials,
+} from "../models/index.js";
+import {
+  resolveRequestTimeoutMs,
+  wrapFetchWithTimeout,
+} from "../requestTimeout.js";
+import { emitDeprecationWarningOnce } from "../deprecationWarnings.js";
+import { authTokenInfoResponseSchema } from "../validation/synergia/auth.js";
+import { parseApiResponse } from "../validation/responseValidation.js";
+
+import {
+  SynergiaApiClient,
+  type SynergiaApiClientOptions,
+} from "./SynergiaApiClient.js";
+
+export interface GatewayApi20AuthClientOptions {
+  fetch?: FetchLike;
+  authBaseUrl?: string;
+  synergiaBaseUrl?: string;
+  requestTimeoutMs?: number;
+}
+
+const AUTHORIZATION_PATH = "/OAuth/Authorization?client_id=46";
+const AUTHORIZATION_PERFORM_LOGIN_PATH =
+  "/OAuth/Authorization/PerformLogin?client_id=46";
+const AUTHORIZATION_GRANT_PATH = "/OAuth/Authorization/Grant?client_id=46";
+const PORTAL_RODZINA_PATH = "/loguj/portalRodzina";
+const TOKEN_INFO_PATH = "/gateway/api/2.0/Auth/TokenInfo";
+
+export class GatewayApi20AuthClient {
+  private readonly cookieFetch: FetchLike;
+  private readonly fetchImpl: FetchLike;
+  private readonly authBaseUrl: string;
+  private readonly synergiaBaseUrl: string;
+  private readonly requestTimeoutMs: number;
+  private loggedIn = false;
+
+  constructor(options: GatewayApi20AuthClientOptions = {}) {
+    const sessionFetch = createSessionFetch(options.fetch ?? fetch);
+
+    this.cookieFetch = sessionFetch.fetch;
+    this.requestTimeoutMs = resolveRequestTimeoutMs(options.requestTimeoutMs);
+    this.fetchImpl = wrapFetchWithTimeout(
+      this.cookieFetch,
+      this.requestTimeoutMs,
+    );
+    this.authBaseUrl = options.authBaseUrl ?? "https://api.librus.pl";
+    this.synergiaBaseUrl =
+      options.synergiaBaseUrl ?? "https://synergia.librus.pl";
+  }
+
+  async login(
+    credentials: GatewayCredentials | SynergiaCredentials,
+  ): Promise<void> {
+    if (this.loggedIn) {
+      return;
+    }
+
+    const normalizedCredentials = normalizeGatewayCredentials(credentials);
+
+    await this.initializePortalSession();
+    await this.getAuthPage();
+    await this.postCredentials(normalizedCredentials);
+    await this.performLogin();
+    await this.performLogin();
+    await this.grantAuthorization();
+    await this.verifyLogin();
+
+    this.loggedIn = true;
+  }
+
+  createApiClient(
+    options: Omit<SynergiaApiClientOptions, "authMode" | "fetch"> = {},
+  ): SynergiaApiClient {
+    return new SynergiaApiClient("", {
+      ...options,
+      apiBaseUrl:
+        options.apiBaseUrl ?? `${this.synergiaBaseUrl}/gateway/api/2.0`,
+      authMode: "cookie",
+      fetch: this.cookieFetch,
+      requestTimeoutMs: options.requestTimeoutMs ?? this.requestTimeoutMs,
+    });
+  }
+
+  isLoggedIn(): boolean {
+    return this.loggedIn;
+  }
+
+  private async initializePortalSession(): Promise<void> {
+    const initUrl = this.buildSynergiaUrl(
+      `${PORTAL_RODZINA_PATH}?v=${Date.now() / 1000}`,
+    );
+    const initResponse = await this.fetchImpl(initUrl, {
+      method: "GET",
+      redirect: "manual",
+      headers: {
+        Referer: "https://portal.librus.pl/",
+      },
+    });
+
+    if (isRedirectResponse(initResponse)) {
+      const location = initResponse.headers.get("location");
+
+      if (!location) {
+        throw new LibrusAuthenticationError(
+          "Gateway API 2.0 authentication failed",
+        );
+      }
+
+      const prepResponse = await this.fetchImpl(
+        new URL(location, initUrl).toString(),
+        {
+          method: "GET",
+          headers: {
+            Referer: "https://portal.librus.pl/",
+          },
+        },
+      );
+
+      this.assertAuthResponse(prepResponse);
+      return;
+    }
+
+    this.assertAuthResponse(initResponse);
+  }
+
+  private async getAuthPage(): Promise<void> {
+    const response = await this.fetchImpl(
+      this.buildAuthUrl(AUTHORIZATION_PATH),
+      {
+        method: "GET",
+      },
+    );
+
+    this.assertAuthResponse(response);
+  }
+
+  private async postCredentials(
+    credentials: GatewayCredentials,
+  ): Promise<void> {
+    const form = new FormData();
+    form.append("action", "login");
+    form.append("login", credentials.login);
+    form.append("pass", credentials.password);
+
+    const response = await this.fetchImpl(
+      this.buildAuthUrl(AUTHORIZATION_PATH),
+      {
+        method: "POST",
+        headers: {
+          Accept: "application/json",
+          "X-Requested-With": "XMLHttpRequest",
+          "X-Baner": createBanerHeader(),
+          Referer: this.buildAuthUrl(AUTHORIZATION_PATH),
+        },
+        body: form,
+      },
+    );
+
+    this.assertAuthResponse(response);
+  }
+
+  private async performLogin(): Promise<void> {
+    const response = await this.fetchImpl(
+      this.buildAuthUrl(AUTHORIZATION_PERFORM_LOGIN_PATH),
+      {
+        method: "GET",
+      },
+    );
+
+    this.assertAuthResponse(response);
+  }
+
+  private async grantAuthorization(): Promise<void> {
+    const response = await this.fetchImpl(
+      this.buildAuthUrl(AUTHORIZATION_GRANT_PATH),
+      {
+        method: "GET",
+      },
+    );
+
+    this.assertAuthResponse(response);
+  }
+
+  private async verifyLogin(): Promise<void> {
+    const endpoint = this.buildSynergiaUrl(TOKEN_INFO_PATH);
+    const response = await this.fetchImpl(endpoint, {
+      method: "GET",
+      headers: {
+        accept: "application/json",
+      },
+    });
+
+    this.assertAuthResponse(response);
+
+    parseApiResponse(
+      authTokenInfoResponseSchema,
+      await response.json(),
+      endpoint,
+    );
+  }
+
+  private buildAuthUrl(path: string): string {
+    return new URL(path, this.authBaseUrl).toString();
+  }
+
+  private buildSynergiaUrl(path: string): string {
+    return new URL(path, this.synergiaBaseUrl).toString();
+  }
+
+  private assertAuthResponse(response: Response): void {
+    if (!response.ok) {
+      throw new LibrusAuthenticationError(
+        "Gateway API 2.0 authentication failed",
+      );
+    }
+  }
+}
+
+function normalizeGatewayCredentials(
+  credentials: GatewayCredentials | SynergiaCredentials,
+): GatewayCredentials {
+  if ("login" in credentials) {
+    return credentials;
+  }
+
+  emitDeprecationWarningOnce(
+    "LIBRUS_SYNERGIA_CREDENTIALS_ID_DEPRECATED",
+    'Gateway credentials with an "id" field are deprecated; use "login" instead.',
+  );
+
+  return {
+    login: credentials.id,
+    password: credentials.password,
+  };
+}
+
+function isRedirectResponse(response: Response): boolean {
+  return response.status >= 300 && response.status < 400;
+}
+
+function createBanerHeader(): string {
+  const timestampPart = encodeBanerSegment(Date.now().toString());
+  const randomPart = encodeBanerSegment(Math.random().toString());
+
+  return `${randomPart}_${timestampPart}`;
+}
+
+function encodeBanerSegment(value: string): string {
+  return value
+    .split("")
+    .map((letter) => String.fromCharCode(letter.charCodeAt(0) + 20))
+    .join("");
+}

--- a/src/sdk/synergia/SynergiaApiClient.ts
+++ b/src/sdk/synergia/SynergiaApiClient.ts
@@ -202,7 +202,7 @@ import {
   getBinary as requestGetBinary,
   getJson as requestGetJson,
 } from "./request.js";
-import type { SynergiaRequestOptions } from "./request.js";
+import type { SynergiaAuthMode, SynergiaRequestOptions } from "./request.js";
 import {
   resolveRequestTimeoutMs,
   wrapFetchWithTimeout,
@@ -211,6 +211,7 @@ import {
 export interface SynergiaApiClientOptions {
   fetch?: FetchLike;
   apiBaseUrl?: string;
+  authMode?: SynergiaAuthMode;
   messageBackend?: MessageReadBackend;
   requestTimeoutMs?: number;
 }
@@ -225,11 +226,13 @@ export class SynergiaApiClient {
   private readonly fetchImpl: FetchLike;
   private readonly apiBaseUrl: string;
   private readonly accessToken: string;
+  private readonly authMode: SynergiaAuthMode;
   private readonly messageBackend: MessageReadBackend | undefined;
   private readonly requestTimeoutMs: number;
 
   constructor(accessToken: string, options: SynergiaApiClientOptions = {}) {
     this.accessToken = accessToken;
+    this.authMode = options.authMode ?? "bearer";
     this.requestTimeoutMs = resolveRequestTimeoutMs(options.requestTimeoutMs);
     this.fetchImpl = wrapFetchWithTimeout(
       options.fetch ?? fetch,
@@ -253,6 +256,7 @@ export class SynergiaApiClient {
       path,
       schema,
       options,
+      this.authMode,
     );
   }
 
@@ -266,6 +270,7 @@ export class SynergiaApiClient {
       this.apiBaseUrl,
       path,
       options,
+      this.authMode,
     );
   }
 

--- a/src/sdk/synergia/request.ts
+++ b/src/sdk/synergia/request.ts
@@ -13,20 +13,31 @@ export interface SynergiaRequestOptions {
   query?: SynergiaQuery;
 }
 
+export type SynergiaAuthMode = "bearer" | "cookie";
+
 const LIBRUS_MOBILE_ORIGIN = "app://librus";
 const LIBRUS_MOBILE_USER_AGENT =
   "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 LibrusMobileApp";
 
 function buildSynergiaHeaders(
   accessToken: string,
+  authMode: SynergiaAuthMode,
   extraHeaders: HeadersInit = {},
 ): HeadersInit {
-  return {
+  const headers: HeadersInit = {
     origin: LIBRUS_MOBILE_ORIGIN,
     "user-agent": LIBRUS_MOBILE_USER_AGENT,
-    authorization: `Bearer ${accessToken}`,
     ...extraHeaders,
   };
+
+  if (authMode === "bearer") {
+    return {
+      ...headers,
+      authorization: `Bearer ${accessToken}`,
+    };
+  }
+
+  return headers;
 }
 
 function normalizeApiBaseUrl(apiBaseUrl: string): string {
@@ -96,11 +107,12 @@ export async function getJson<
   path: string,
   schema: TSchema,
   options: SynergiaRequestOptions = {},
+  authMode: SynergiaAuthMode = "bearer",
 ): Promise<InferOutput<TSchema>> {
   const endpoint = buildEndpoint(apiBaseUrl, path, options.query);
   const response = await fetchImpl(endpoint, {
     method: "GET",
-    headers: buildSynergiaHeaders(accessToken, {
+    headers: buildSynergiaHeaders(accessToken, authMode, {
       accept: "application/json",
     }),
   });
@@ -118,11 +130,12 @@ export async function getBinary(
   apiBaseUrl: string,
   path: string,
   options: SynergiaRequestOptions = {},
+  authMode: SynergiaAuthMode = "bearer",
 ): Promise<SynergiaBinaryResult> {
   const endpoint = buildEndpoint(apiBaseUrl, path, options.query);
   const response = await fetchImpl(endpoint, {
     method: "GET",
-    headers: buildSynergiaHeaders(accessToken),
+    headers: buildSynergiaHeaders(accessToken, authMode),
   });
 
   if (!response.ok) {

--- a/test/cli-high-value.test.ts
+++ b/test/cli-high-value.test.ts
@@ -66,6 +66,8 @@ function createCommandContext(
       outputWidth: 80,
       createSession: () =>
         ({
+          getApiBackend: () => "api_v3",
+          getAuthMode: () => "portal",
           resolveChild,
           forChild,
           forChildWiadomosci,
@@ -81,6 +83,17 @@ function createCommandContext(
 }
 
 const successCases = [
+  {
+    name: "me",
+    argv: ["node", "librus", "me", "--child", "child-login"],
+    method: "getMe",
+    response: {
+      Me: { Id: 1, FirstName: "Child", LastName: "Name" },
+      Resources: {},
+      Url: "https://api.librus.pl/3.0/Me",
+    },
+    expectedArgs: [],
+  },
   {
     name: "messages list",
     argv: ["node", "librus", "messages", "list", "--child", "child-login"],
@@ -271,7 +284,8 @@ const usageFailureCases = [
   {
     name: "messages list requires child",
     argv: ["node", "librus", "messages", "list"],
-    expectedMessage: "required option '--child <id-or-login>' not specified",
+    expectedCode: "CHILD_REQUIRED",
+    expectedMessage: "Pass --child <id-or-login> or set LIBRUS_CHILD.",
   },
   {
     name: "messages get requires id",
@@ -281,12 +295,14 @@ const usageFailureCases = [
   {
     name: "messages unread requires child",
     argv: ["node", "librus", "messages", "unread"],
-    expectedMessage: "required option '--child <id-or-login>' not specified",
+    expectedCode: "CHILD_REQUIRED",
+    expectedMessage: "Pass --child <id-or-login> or set LIBRUS_CHILD.",
   },
   {
     name: "messages bff-list requires child",
     argv: ["node", "librus", "messages", "bff-list"],
-    expectedMessage: "required option '--child <id-or-login>' not specified",
+    expectedCode: "CHILD_REQUIRED",
+    expectedMessage: "Pass --child <id-or-login> or set LIBRUS_CHILD.",
   },
   {
     name: "messages list rejects invalid backend",
@@ -305,7 +321,8 @@ const usageFailureCases = [
   {
     name: "messages wiadomosci-list requires child",
     argv: ["node", "librus", "messages", "wiadomosci-list"],
-    expectedMessage: "required option '--child <id-or-login>' not specified",
+    expectedCode: "CHILD_REQUIRED",
+    expectedMessage: "Pass --child <id-or-login> or set LIBRUS_CHILD.",
   },
   {
     name: "messages wiadomosci-get requires id",
@@ -322,7 +339,8 @@ const usageFailureCases = [
   {
     name: "messages wiadomosci-unread requires child",
     argv: ["node", "librus", "messages", "wiadomosci-unread"],
-    expectedMessage: "required option '--child <id-or-login>' not specified",
+    expectedCode: "CHILD_REQUIRED",
+    expectedMessage: "Pass --child <id-or-login> or set LIBRUS_CHILD.",
   },
   {
     name: "timetable week requires week start",
@@ -343,7 +361,8 @@ const usageFailureCases = [
   {
     name: "announcements list requires child",
     argv: ["node", "librus", "announcements", "list"],
-    expectedMessage: "required option '--child <id-or-login>' not specified",
+    expectedCode: "CHILD_REQUIRED",
+    expectedMessage: "Pass --child <id-or-login> or set LIBRUS_CHILD.",
   },
   {
     name: "announcements get requires id",
@@ -353,7 +372,8 @@ const usageFailureCases = [
   {
     name: "notes list requires child",
     argv: ["node", "librus", "notes", "list"],
-    expectedMessage: "required option '--child <id-or-login>' not specified",
+    expectedCode: "CHILD_REQUIRED",
+    expectedMessage: "Pass --child <id-or-login> or set LIBRUS_CHILD.",
   },
   {
     name: "notes get requires id",
@@ -394,13 +414,17 @@ describe("runCli high-value commands", () => {
 
   it.each(usageFailureCases)(
     "keeps usage failures for $name",
-    async ({ argv, expectedMessage }) => {
+    async ({ argv, expectedCode = "CLI_USAGE_ERROR", expectedMessage }) => {
       let stderr = "";
 
       const exitCode = await runCli(withJsonFormat(argv), {
         stdout: { write: () => undefined },
         stderr: { write: (chunk) => (stderr += chunk) },
-        createSession: () => ({}) as never,
+        createSession: () =>
+          ({
+            getApiBackend: () => "api_v3",
+            getAuthMode: () => "portal",
+          }) as never,
         outputWidth: 80,
       });
 
@@ -409,7 +433,7 @@ describe("runCli high-value commands", () => {
       );
 
       expect(exitCode).not.toBe(0);
-      expect(output.error.code).toBe("CLI_USAGE_ERROR");
+      expect(output.error.code).toBe(expectedCode);
       expect(output.error.message).toContain(expectedMessage);
     },
   );
@@ -599,6 +623,8 @@ describe("runCli high-value commands", () => {
         outputWidth: 80,
         createSession: () =>
           ({
+            getApiBackend: () => "api_v3",
+            getAuthMode: () => "portal",
             resolveChild: async () => createChild(),
             forChild: async () => {
               throw new LibrusSdkError(

--- a/test/cli-supporting.test.ts
+++ b/test/cli-supporting.test.ts
@@ -46,6 +46,8 @@ function createCommandContext(
       outputWidth: 80,
       createSession: () =>
         ({
+          getApiBackend: () => "api_v3",
+          getAuthMode: () => "portal",
           resolveChild,
           forChild,
         }) as never,
@@ -57,6 +59,28 @@ function createCommandContext(
 }
 
 const successCases = [
+  {
+    name: "attendance list",
+    argv: ["node", "librus", "attendance", "list", "--child", "child-login"],
+    method: "getAttendances",
+    response: {
+      Attendances: [],
+      Resources: {},
+      Url: "https://api.librus.pl/3.0/Attendances",
+    },
+    expectedArgs: [],
+  },
+  {
+    name: "homework list",
+    argv: ["node", "librus", "homework", "list", "--child", "child-login"],
+    method: "getHomeWorks",
+    response: {
+      HomeWorks: [],
+      Resources: {},
+      Url: "https://api.librus.pl/3.0/HomeWorks",
+    },
+    expectedArgs: [],
+  },
   {
     name: "lessons list",
     argv: ["node", "librus", "lessons", "list", "--child", "child-login"],
@@ -414,7 +438,8 @@ const usageFailureCases = [
   {
     name: "lucky-number get requires child",
     argv: ["node", "librus", "lucky-number", "get"],
-    expectedMessage: "required option '--child <id-or-login>' not specified",
+    expectedCode: "CHILD_REQUIRED",
+    expectedMessage: "Pass --child <id-or-login> or set LIBRUS_CHILD.",
   },
   {
     name: "justifications get requires id",
@@ -496,6 +521,8 @@ describe("supporting CLI commands", () => {
         outputWidth: 80,
         createSession: () =>
           ({
+            getApiBackend: () => "api_v3",
+            getAuthMode: () => "portal",
             resolveChild,
             forChild,
           }) as never,
@@ -561,6 +588,8 @@ describe("supporting CLI commands", () => {
         outputWidth: 80,
         createSession: () =>
           ({
+            getApiBackend: () => "api_v3",
+            getAuthMode: () => "portal",
             resolveChild,
             forChild,
           }) as never,
@@ -620,6 +649,8 @@ describe("supporting CLI commands", () => {
         outputWidth: 80,
         createSession: () =>
           ({
+            getApiBackend: () => "api_v3",
+            getAuthMode: () => "portal",
             resolveChild,
             forChild,
           }) as never,
@@ -714,6 +745,8 @@ describe("supporting CLI commands", () => {
           outputWidth: 80,
           createSession: () =>
             ({
+              getApiBackend: () => "api_v3",
+              getAuthMode: () => "portal",
               resolveChild,
               forChild,
             }) as never,
@@ -768,6 +801,8 @@ describe("supporting CLI commands", () => {
         outputWidth: 80,
         createSession: () =>
           ({
+            getApiBackend: () => "api_v3",
+            getAuthMode: () => "portal",
             resolveChild,
             forChild,
           }) as never,
@@ -817,6 +852,8 @@ describe("supporting CLI commands", () => {
         outputWidth: 80,
         createSession: () =>
           ({
+            getApiBackend: () => "api_v3",
+            getAuthMode: () => "portal",
             resolveChild,
             forChild,
           }) as never,
@@ -832,28 +869,33 @@ describe("supporting CLI commands", () => {
     expect(output.error.code).toBe("RESPONSE_VALIDATION_FAILED");
   });
 
-  it.each(usageFailureCases)("$name", async ({ argv, expectedMessage }) => {
-    let stderr = "";
+  it.each(usageFailureCases)(
+    "$name",
+    async ({ argv, expectedCode = "CLI_USAGE_ERROR", expectedMessage }) => {
+      let stderr = "";
 
-    const exitCode = await runCli(withJsonFormat(argv), {
-      stdout: { write: () => undefined },
-      stderr: { write: (chunk) => (stderr += chunk) },
-      outputWidth: 80,
-      createSession: () =>
-        ({
-          resolveChild: vi.fn(),
-          forChild: vi.fn(),
-        }) as never,
-    });
+      const exitCode = await runCli(withJsonFormat(argv), {
+        stdout: { write: () => undefined },
+        stderr: { write: (chunk) => (stderr += chunk) },
+        outputWidth: 80,
+        createSession: () =>
+          ({
+            getApiBackend: () => "api_v3",
+            getAuthMode: () => "portal",
+            resolveChild: vi.fn(),
+            forChild: vi.fn(),
+          }) as never,
+      });
 
-    const output = parseJson<{ error: { code: string; message: string } }>(
-      stderr,
-    );
+      const output = parseJson<{ error: { code: string; message: string } }>(
+        stderr,
+      );
 
-    expect(exitCode).not.toBe(0);
-    expect(output.error.code).toBe("CLI_USAGE_ERROR");
-    expect(output.error.message).toContain(expectedMessage);
-  });
+      expect(exitCode).not.toBe(0);
+      expect(output.error.code).toBe(expectedCode);
+      expect(output.error.message).toContain(expectedMessage);
+    },
+  );
 
   it("renders text output by default for lessons list", async () => {
     const { context, getOutput } = createCommandContext("listLessons", {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -10,7 +10,7 @@ import {
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { pathToFileURL } from "node:url";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   isCliEntryPoint,
@@ -31,6 +31,20 @@ import {
 const packageJson = JSON.parse(
   readFileSync(new URL("../package.json", import.meta.url), "utf8"),
 ) as { bin: Record<string, string>; version: string };
+const originalLibrusChild = process.env.LIBRUS_CHILD;
+
+beforeEach(() => {
+  delete process.env.LIBRUS_CHILD;
+});
+
+afterEach(() => {
+  if (originalLibrusChild === undefined) {
+    delete process.env.LIBRUS_CHILD;
+    return;
+  }
+
+  process.env.LIBRUS_CHILD = originalLibrusChild;
+});
 
 function createChild(overrides: Partial<ChildAccount> = {}): ChildAccount {
   return {
@@ -46,17 +60,35 @@ function createChild(overrides: Partial<ChildAccount> = {}): ChildAccount {
 }
 
 function createSessionStub(child = createChild()) {
+  const resolveChild = vi.fn(async () => child);
+
   return {
+    getApiBackend: () => "api_v3",
+    getAuthMode: () => "portal",
     getSynergiaAccounts: async () => ({
       lastModification: 999,
       accounts: [child],
     }),
-    resolveChild: async () => child,
+    resolveChild,
     forChild: async () => ({
       getGrades: async () => ({
         Grades: [],
         Resources: {},
         Url: "https://api.librus.pl/3.0/Grades",
+      }),
+    }),
+  };
+}
+
+function createGatewayApi20SessionStub() {
+  return {
+    getApiBackend: () => "gateway_api_20",
+    getAuthMode: () => "synergia",
+    forChild: async () => ({
+      getGrades: async () => ({
+        Grades: [],
+        Resources: {},
+        Url: "https://synergia.librus.pl/gateway/api/2.0/Grades",
       }),
     }),
   };
@@ -119,6 +151,131 @@ describe("runCli", () => {
     expect(stderr).toBe("");
     expect(output.lastModification).toBe(999);
     expect(output.children[0]).not.toHaveProperty("accessToken");
+  });
+
+  it("runs child-scoped API commands without --child in gateway_api_20", async () => {
+    let stdout = "";
+    let stderr = "";
+    const exitCode = await runCli(
+      withJsonFormat(["node", "librus", "grades", "list"]),
+      {
+        stdout: { write: (chunk) => (stdout += chunk) },
+        stderr: { write: (chunk) => (stderr += chunk) },
+        createSession: () => createGatewayApi20SessionStub() as never,
+        outputWidth: 80,
+      },
+    );
+    const output = parseJson<{ data: { Grades: unknown[] } }>(stdout);
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe("");
+    expect(output.data.Grades).toEqual([]);
+  });
+
+  it("returns a structured unsupported error when gateway_api_20 receives --child", async () => {
+    let stdout = "";
+    let stderr = "";
+    const exitCode = await runCli(
+      withJsonFormat([
+        "node",
+        "librus",
+        "grades",
+        "list",
+        "--child",
+        "child-login",
+      ]),
+      {
+        stdout: { write: (chunk) => (stdout += chunk) },
+        stderr: { write: (chunk) => (stderr += chunk) },
+        createSession: () => createGatewayApi20SessionStub() as never,
+        outputWidth: 80,
+      },
+    );
+    const output = parseJson<{
+      error: {
+        code: string;
+        message: string;
+        details: { apiBackend: string };
+      };
+    }>(stderr);
+
+    expect(exitCode).toBe(1);
+    expect(stdout).toBe("");
+    expect(output.error.code).toBe("UNSUPPORTED_BACKEND");
+    expect(output.error.message).toContain("gateway_api_20");
+    expect(output.error.details).toEqual({ apiBackend: "gateway_api_20" });
+  });
+
+  it("returns a structured child-required error when portal mode omits --child", async () => {
+    let stdout = "";
+    let stderr = "";
+    const exitCode = await runCli(
+      withJsonFormat(["node", "librus", "grades", "list"]),
+      {
+        stdout: { write: (chunk) => (stdout += chunk) },
+        stderr: { write: (chunk) => (stderr += chunk) },
+        createSession: () => createSessionStub() as never,
+        outputWidth: 80,
+      },
+    );
+    const output = parseJson<{ error: { code: string; message: string } }>(
+      stderr,
+    );
+
+    expect(exitCode).toBe(1);
+    expect(stdout).toBe("");
+    expect(output.error.code).toBe("CHILD_REQUIRED");
+    expect(output.error.message).toContain("--child <id-or-login>");
+  });
+
+  it("uses LIBRUS_CHILD as the api_v3 default child selector", async () => {
+    process.env.LIBRUS_CHILD = "env-child";
+    let stdout = "";
+    let stderr = "";
+    const session = createSessionStub();
+    const exitCode = await runCli(
+      withJsonFormat(["node", "librus", "grades", "list"]),
+      {
+        stdout: { write: (chunk) => (stdout += chunk) },
+        stderr: { write: (chunk) => (stderr += chunk) },
+        createSession: () => session as never,
+        outputWidth: 80,
+      },
+    );
+    const output = parseJson<{ data: { Grades: unknown[] } }>(stdout);
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe("");
+    expect(session.resolveChild).toHaveBeenCalledWith("env-child");
+    expect(output.data.Grades).toEqual([]);
+  });
+
+  it("lets --child override LIBRUS_CHILD in api_v3", async () => {
+    process.env.LIBRUS_CHILD = "env-child";
+    let stdout = "";
+    let stderr = "";
+    const session = createSessionStub();
+    const exitCode = await runCli(
+      withJsonFormat([
+        "node",
+        "librus",
+        "grades",
+        "list",
+        "--child",
+        "cli-child",
+      ]),
+      {
+        stdout: { write: (chunk) => (stdout += chunk) },
+        stderr: { write: (chunk) => (stderr += chunk) },
+        createSession: () => session as never,
+        outputWidth: 80,
+      },
+    );
+
+    expect(exitCode).toBe(0);
+    expect(stdout).not.toBe("");
+    expect(stderr).toBe("");
+    expect(session.resolveChild).toHaveBeenCalledWith("cli-child");
   });
 
   it("prints root help and exits successfully when no command is provided", async () => {
@@ -307,7 +464,7 @@ describe("runCli", () => {
     expect(stderr).toContain("5000");
   });
 
-  it("keeps usage errors as failures", async () => {
+  it("keeps portal child requirement errors as failures", async () => {
     let stderr = "";
     const processStderrWrite = vi
       .spyOn(process.stderr, "write")
@@ -321,8 +478,9 @@ describe("runCli", () => {
     });
 
     expect(exitCode).not.toBe(0);
-    expect(stderr).toContain("CLI_USAGE_ERROR");
-    expect(stderr).toContain("required option");
+    expect(stderr).toContain("CHILD_REQUIRED");
+    expect(stderr).toContain("--child");
+    expect(stderr).toContain("<id-or-login>");
     expect(processStderrWrite).not.toHaveBeenCalled();
     processStderrWrite.mockRestore();
   });

--- a/test/direct-synergia-auth-client.test.ts
+++ b/test/direct-synergia-auth-client.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  DirectSynergiaAuthClient,
+  GatewayApi20AuthClient,
+  LibrusAuthenticationError,
+} from "../src/sdk/index.js";
+
+function responseJson(value: unknown, status = 200): Response {
+  return new Response(JSON.stringify(value), {
+    headers: { "content-type": "application/json" },
+    status,
+  });
+}
+
+function redirectResponse(location: string): Response {
+  return new Response("", {
+    headers: { location },
+    status: 302,
+  });
+}
+
+function mockSuccessfulLogin(
+  fetchMock: ReturnType<typeof vi.fn<typeof fetch>>,
+) {
+  fetchMock
+    .mockResolvedValueOnce(
+      redirectResponse(
+        "https://api.librus.pl/OAuth/Authorization?client_id=46&response_type=code&scope=mydata&state=test-state",
+      ),
+    )
+    .mockResolvedValueOnce(new Response("<html>prep</html>"))
+    .mockResolvedValueOnce(new Response("<html>auth</html>"))
+    .mockResolvedValueOnce(responseJson({ status: "ok" }))
+    .mockResolvedValueOnce(new Response("", { status: 200 }))
+    .mockResolvedValueOnce(new Response("", { status: 200 }))
+    .mockResolvedValueOnce(new Response("", { status: 200 }))
+    .mockResolvedValueOnce(
+      responseJson({
+        Resources: {},
+        Url: "https://synergia.librus.pl/gateway/api/2.0/Auth/TokenInfo",
+        UserIdentifier: "1234567",
+      }),
+    );
+}
+
+function getRequestUrl(input: RequestInfo | URL): string {
+  return typeof input === "string"
+    ? input
+    : input instanceof URL
+      ? input.toString()
+      : input.url;
+}
+
+function getRequestInit(init: RequestInit | undefined): RequestInit {
+  return init ?? {};
+}
+
+function expectDeprecationWarning(
+  warnings: Parameters<typeof process.emitWarning>[],
+  code: string,
+): void {
+  expect(warnings).toEqual(
+    expect.arrayContaining([
+      expect.arrayContaining([
+        expect.any(String),
+        expect.objectContaining({
+          code,
+          type: "DeprecationWarning",
+        }),
+      ]),
+    ]),
+  );
+}
+
+describe("GatewayApi20AuthClient", () => {
+  it("keeps DirectSynergiaAuthClient as a compatibility alias with a warning", () => {
+    const emitWarning = vi
+      .spyOn(process, "emitWarning")
+      .mockImplementation(() => undefined);
+
+    try {
+      const client = new DirectSynergiaAuthClient();
+
+      expect(client).toBeInstanceOf(GatewayApi20AuthClient);
+      expectDeprecationWarning(
+        emitWarning.mock.calls,
+        "LIBRUS_DIRECT_SYNERGIA_AUTH_CLIENT_CLASS_DEPRECATED",
+      );
+    } finally {
+      emitWarning.mockRestore();
+    }
+  });
+
+  it("performs the gateway API 2.0 OAuth login sequence", async () => {
+    const fetchMock = vi.fn<typeof fetch>();
+    mockSuccessfulLogin(fetchMock);
+    const client = new GatewayApi20AuthClient({ fetch: fetchMock });
+
+    await client.login({ login: "1234567", password: "super-secret" });
+
+    expect(fetchMock).toHaveBeenCalledTimes(8);
+    expect(getRequestUrl(fetchMock.mock.calls[0]![0])).toMatch(
+      /^https:\/\/synergia\.librus\.pl\/loguj\/portalRodzina\?v=/,
+    );
+    expect(getRequestInit(fetchMock.mock.calls[0]![1]).redirect).toBe("manual");
+    expect(getRequestUrl(fetchMock.mock.calls[1]![0])).toBe(
+      "https://api.librus.pl/OAuth/Authorization?client_id=46&response_type=code&scope=mydata&state=test-state",
+    );
+    expect(getRequestUrl(fetchMock.mock.calls[2]![0])).toBe(
+      "https://api.librus.pl/OAuth/Authorization?client_id=46",
+    );
+    expect(getRequestUrl(fetchMock.mock.calls[3]![0])).toBe(
+      "https://api.librus.pl/OAuth/Authorization?client_id=46",
+    );
+    expect(getRequestInit(fetchMock.mock.calls[3]![1]).method).toBe("POST");
+
+    const credentialsBody = getRequestInit(fetchMock.mock.calls[3]![1])
+      .body as FormData;
+    const credentialsHeaders = new Headers(
+      getRequestInit(fetchMock.mock.calls[3]![1]).headers,
+    );
+
+    expect(credentialsBody).toBeInstanceOf(FormData);
+    expect(credentialsBody.get("action")).toBe("login");
+    expect(credentialsBody.get("login")).toBe("1234567");
+    expect(credentialsBody.get("pass")).toBe("super-secret");
+    expect(credentialsHeaders.get("accept")).toBe("application/json");
+    expect(credentialsHeaders.get("x-requested-with")).toBe("XMLHttpRequest");
+    expect(credentialsHeaders.get("x-baner")).toBeTruthy();
+    expect(credentialsHeaders.get("referer")).toBe(
+      "https://api.librus.pl/OAuth/Authorization?client_id=46",
+    );
+    expect(getRequestUrl(fetchMock.mock.calls[4]![0])).toBe(
+      "https://api.librus.pl/OAuth/Authorization/PerformLogin?client_id=46",
+    );
+    expect(getRequestUrl(fetchMock.mock.calls[5]![0])).toBe(
+      "https://api.librus.pl/OAuth/Authorization/PerformLogin?client_id=46",
+    );
+    expect(getRequestUrl(fetchMock.mock.calls[6]![0])).toBe(
+      "https://api.librus.pl/OAuth/Authorization/Grant?client_id=46",
+    );
+    expect(getRequestUrl(fetchMock.mock.calls[7]![0])).toBe(
+      "https://synergia.librus.pl/gateway/api/2.0/Auth/TokenInfo",
+    );
+  });
+
+  it("accepts legacy id-shaped credentials with a warning", async () => {
+    const fetchMock = vi.fn<typeof fetch>();
+    mockSuccessfulLogin(fetchMock);
+    const client = new GatewayApi20AuthClient({ fetch: fetchMock });
+    const emitWarning = vi
+      .spyOn(process, "emitWarning")
+      .mockImplementation(() => undefined);
+
+    try {
+      await client.login({ id: "1234567", password: "super-secret" });
+
+      expectDeprecationWarning(
+        emitWarning.mock.calls,
+        "LIBRUS_SYNERGIA_CREDENTIALS_ID_DEPRECATED",
+      );
+    } finally {
+      emitWarning.mockRestore();
+    }
+  });
+
+  it("uses the OAuth grant URL even when gateway login returns a continuation hint", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        redirectResponse(
+          "https://api.librus.pl/OAuth/Authorization?client_id=46&response_type=code&scope=mydata&state=test-state",
+        ),
+      )
+      .mockResolvedValueOnce(new Response("<html>prep</html>"))
+      .mockResolvedValueOnce(new Response("<html>auth</html>"))
+      .mockResolvedValueOnce(
+        responseJson({
+          status: "ok",
+          goTo: "/OAuth/Authorization/2FA?client_id=46",
+        }),
+      )
+      .mockResolvedValueOnce(new Response("", { status: 200 }))
+      .mockResolvedValueOnce(new Response("", { status: 200 }))
+      .mockResolvedValueOnce(new Response("", { status: 200 }))
+      .mockResolvedValueOnce(
+        responseJson({
+          Resources: {},
+          Url: "https://synergia.librus.pl/gateway/api/2.0/Auth/TokenInfo",
+          UserIdentifier: "1234567",
+        }),
+      );
+    const client = new GatewayApi20AuthClient({ fetch: fetchMock });
+
+    await client.login({ login: "1234567", password: "super-secret" });
+
+    expect(fetchMock).toHaveBeenCalledTimes(8);
+    expect(getRequestUrl(fetchMock.mock.calls[6]![0])).toBe(
+      "https://api.librus.pl/OAuth/Authorization/Grant?client_id=46",
+    );
+    expect(getRequestUrl(fetchMock.mock.calls[7]![0])).toBe(
+      "https://synergia.librus.pl/gateway/api/2.0/Auth/TokenInfo",
+    );
+  });
+
+  it("fails invalid gateway credentials without leaking secrets", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        redirectResponse(
+          "https://api.librus.pl/OAuth/Authorization?client_id=46&response_type=code&scope=mydata&state=test-state",
+        ),
+      )
+      .mockResolvedValueOnce(new Response("<html>prep</html>"))
+      .mockResolvedValueOnce(new Response("<html>auth</html>"))
+      .mockResolvedValueOnce(responseJson({ error: "denied" }, 401));
+    const client = new GatewayApi20AuthClient({ fetch: fetchMock });
+    const error = await client
+      .login({ login: "1234567", password: "super-secret" })
+      .catch((loginError: unknown) => loginError);
+
+    expect(error).toBeInstanceOf(LibrusAuthenticationError);
+    expect(JSON.stringify(error)).not.toContain("1234567");
+    expect(JSON.stringify(error)).not.toContain("super-secret");
+  });
+
+  it("creates a cookie-mode Synergia API client", async () => {
+    const fetchMock = vi.fn<typeof fetch>();
+    mockSuccessfulLogin(fetchMock);
+    fetchMock.mockResolvedValueOnce(
+      responseJson({
+        Me: {
+          Account: {},
+          Class: null,
+          Refresh: false,
+          User: {},
+        },
+        Resources: {},
+        Url: "https://synergia.librus.pl/gateway/api/2.0/Me",
+      }),
+    );
+    const authClient = new GatewayApi20AuthClient({ fetch: fetchMock });
+
+    await authClient.login({ login: "1234567", password: "super-secret" });
+    const apiClient = authClient.createApiClient();
+    await apiClient.getMe();
+
+    const apiRequest = fetchMock.mock.calls[8]!;
+    const apiHeaders = new Headers(getRequestInit(apiRequest[1]).headers);
+
+    expect(getRequestUrl(apiRequest[0])).toBe(
+      "https://synergia.librus.pl/gateway/api/2.0/Me",
+    );
+    expect(apiHeaders.get("authorization")).toBeNull();
+  });
+});

--- a/test/integration/helpers/children.mjs
+++ b/test/integration/helpers/children.mjs
@@ -5,6 +5,32 @@ function normalizeSelectors(raw) {
     .filter(Boolean);
 }
 
+export const GATEWAY_API_20_CHILD = {
+  id: "gateway-api-20",
+  login: "LIBRUS_GATEWAY_LOGIN",
+  studentName: "Gateway API 2.0 account",
+};
+
+export function isGatewayApi20Mode(env = process.env) {
+  if (env.LIBRUS_API_BACKEND === "gateway_api_20") {
+    return true;
+  }
+
+  if (env.LIBRUS_API_BACKEND === "api_v3") {
+    return false;
+  }
+
+  if (env.LIBRUS_AUTH_MODE === "synergia") {
+    return true;
+  }
+
+  if (hasCompletePortalCredentials(env)) {
+    return false;
+  }
+
+  return hasCompleteGatewayCredentials(env);
+}
+
 export function summarizeChild(child) {
   return {
     id: child.id,
@@ -36,4 +62,22 @@ export function selectTargetChildren(children, env = process.env) {
   }
 
   return selectedChildren;
+}
+
+function hasCompletePortalCredentials(env) {
+  return Boolean(
+    resolveCredential(env, "LIBRUS_PORTAL_EMAIL", "LIBRUS_EMAIL") &&
+    resolveCredential(env, "LIBRUS_PORTAL_PASSWORD", "LIBRUS_PASSWORD"),
+  );
+}
+
+function hasCompleteGatewayCredentials(env) {
+  return Boolean(
+    resolveCredential(env, "LIBRUS_GATEWAY_LOGIN", "SYNERGIA_ID") &&
+    resolveCredential(env, "LIBRUS_GATEWAY_PASSWORD", "SYNERGIA_PASSWORD"),
+  );
+}
+
+function resolveCredential(env, primary, fallback) {
+  return env[primary] ?? env[fallback];
 }

--- a/test/integration/helpers/cli.mjs
+++ b/test/integration/helpers/cli.mjs
@@ -4,7 +4,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { selectTargetChildren, summarizeChild } from "./children.mjs";
+import {
+  GATEWAY_API_20_CHILD,
+  isGatewayApi20Mode,
+  selectTargetChildren,
+  summarizeChild,
+} from "./children.mjs";
 
 const MAX_BUFFER_BYTES = 20 * 1024 * 1024;
 const repoRoot = fileURLToPath(new URL("../../../", import.meta.url));
@@ -521,7 +526,320 @@ export function summarizeCliResult(result) {
   };
 }
 
+function commandKey(args) {
+  return args.join("\u0000");
+}
+
+function runGatewayApi20CliMatrix(env) {
+  assertBuiltCli();
+
+  const targetResults = [];
+  const childCommandResults = new Map();
+  const currentDay = getCurrentDay();
+  const currentWeekStart = getCurrentWeekStart();
+  const downloadDir = mkdtempSync(join(tmpdir(), "librus-sdk-cli-"));
+  const gatewayArgs = [
+    ["me"],
+    ["grades", "list"],
+    ["attendance", "list"],
+    ["homework", "list"],
+    ["messages", "list"],
+    ["messages", "unread"],
+    ["timetable", "day", "--day", currentDay],
+    ["timetable", "week", "--week-start", currentWeekStart],
+    ["announcements", "list"],
+    ["notes", "list"],
+    ["lessons", "list"],
+    ["lessons", "planned-list"],
+    ["lessons", "realizations-list"],
+    ["lucky-number", "get"],
+    ["notifications", "center"],
+    ["notifications", "push-configurations"],
+    ["justifications", "conferences"],
+    ["justifications", "system-data"],
+    ["auth", "photos"],
+    ["auth", "token-info"],
+  ];
+
+  try {
+    targetResults.push(
+      skippedCliResult(
+        ["children", "list"],
+        "Gateway API 2.0 mode is already child-scoped and has no Portal child list.",
+      ),
+      skippedCliResult(
+        ["messages", "bff-list"],
+        "BFF messages require Portal child tokens.",
+      ),
+      skippedCliResult(
+        ["messages", "wiadomosci-list"],
+        "The wiadomosci backend requires Portal authentication.",
+      ),
+    );
+
+    for (const args of gatewayArgs) {
+      const result = runCliCommand(args, env);
+
+      childCommandResults.set(commandKey(args), result);
+      targetResults.push(
+        isDefaultApi3MessageCommand(args)
+          ? summarizeOrSkipCliStatus(
+              result,
+              403,
+              "Gateway API 2.0 messages returned 403 for this gateway_api_20 account.",
+            )
+          : summarizeCliResult(result),
+      );
+    }
+
+    const messagesList = childCommandResults.get(
+      commandKey(["messages", "list"]),
+    );
+    const messageId = findEntityId(messagesList.payload?.data?.Messages);
+
+    targetResults.push(
+      messageId === null
+        ? skippedCliResult(
+            ["messages", "get", "--id", "<id>"],
+            "No message id found in the live messages payload.",
+          )
+        : summarizeOrSkipCliStatus(
+            runCliCommand(["messages", "get", "--id", String(messageId)], env),
+            403,
+            "Gateway API 2.0 message detail returned 403 for this gateway_api_20 account.",
+          ),
+    );
+
+    const timetableDay = childCommandResults.get(
+      commandKey(["timetable", "day", "--day", currentDay]),
+    );
+    const timetableEntryId = findTimetableEntryId(
+      timetableDay.payload?.data?.Timetable,
+    );
+
+    targetResults.push(
+      timetableEntryId === null
+        ? skippedCliResult(
+            ["timetable", "entry", "--id", "<id>"],
+            "No timetable entry id found in the current day payload.",
+          )
+        : summarizeCliResult(
+            runCliCommand(
+              ["timetable", "entry", "--id", String(timetableEntryId)],
+              env,
+            ),
+          ),
+    );
+
+    const announcementsList = childCommandResults.get(
+      commandKey(["announcements", "list"]),
+    );
+    const announcementId = findEntityId(
+      announcementsList.payload?.data?.SchoolNotices,
+    );
+
+    targetResults.push(
+      announcementId === null
+        ? skippedCliResult(
+            ["announcements", "get", "--id", "<id>"],
+            "No school notice id found in the live payload.",
+          )
+        : summarizeCliResult(
+            runCliCommand(
+              ["announcements", "get", "--id", String(announcementId)],
+              env,
+            ),
+          ),
+    );
+
+    const notesList = childCommandResults.get(commandKey(["notes", "list"]));
+    const noteId = findEntityId(notesList.payload?.data?.Notes);
+
+    targetResults.push(
+      noteId === null
+        ? skippedCliResult(
+            ["notes", "get", "--id", "<id>"],
+            "No note id found in the live payload.",
+          )
+        : summarizeCliResult(
+            runCliCommand(["notes", "get", "--id", String(noteId)], env),
+          ),
+    );
+
+    const lessonsList = childCommandResults.get(
+      commandKey(["lessons", "list"]),
+    );
+    const lessonId = findEntityId(lessonsList.payload?.data?.Lessons);
+
+    targetResults.push(
+      lessonId === null
+        ? skippedCliResult(
+            ["lessons", "get", "--id", "<id>"],
+            "No lesson id found in the live lessons payload.",
+          )
+        : summarizeCliResult(
+            runCliCommand(["lessons", "get", "--id", String(lessonId)], env),
+          ),
+    );
+
+    const plannedLessonsList = childCommandResults.get(
+      commandKey(["lessons", "planned-list"]),
+    );
+    const plannedLessonId = findEntityId(
+      plannedLessonsList.payload?.data?.PlannedLessons,
+    );
+    const plannedAttachmentId = findAttachmentId(
+      plannedLessonsList.payload?.data?.PlannedLessons,
+    );
+
+    targetResults.push(
+      plannedLessonId === null
+        ? skippedCliResult(
+            ["lessons", "planned-get", "--id", "<id>"],
+            "No planned lesson id found in the live payload.",
+          )
+        : summarizeCliResult(
+            runCliCommand(
+              ["lessons", "planned-get", "--id", String(plannedLessonId)],
+              env,
+            ),
+          ),
+    );
+
+    targetResults.push(
+      plannedAttachmentId === null
+        ? skippedCliResult(
+            [
+              "lessons",
+              "planned-attachment",
+              "--id",
+              "<id>",
+              "--output",
+              "<path>",
+            ],
+            "No planned lesson attachment id found in the live payload.",
+          )
+        : summarizeCliResult(
+            runCliCommand(
+              [
+                "lessons",
+                "planned-attachment",
+                "--id",
+                String(plannedAttachmentId),
+                "--output",
+                join(downloadDir, "planned-gateway-api-20.bin"),
+              ],
+              env,
+            ),
+          ),
+    );
+
+    const realizationsList = childCommandResults.get(
+      commandKey(["lessons", "realizations-list"]),
+    );
+    const realizationId = findEntityId(
+      realizationsList.payload?.data?.Realizations,
+    );
+
+    targetResults.push(
+      realizationId === null
+        ? skippedCliResult(
+            ["lessons", "realizations-get", "--id", "<id>"],
+            "No realization id found in the live payload.",
+          )
+        : summarizeCliResult(
+            runCliCommand(
+              ["lessons", "realizations-get", "--id", String(realizationId)],
+              env,
+            ),
+          ),
+    );
+
+    const justificationsList = runCliCommand(["justifications", "list"], env);
+    targetResults.push(
+      summarizeOrSkipCliStatus(
+        justificationsList,
+        403,
+        "Justifications are disabled or unreadable for this account.",
+      ),
+    );
+
+    const justificationId = findEntityId(
+      justificationsList.payload?.data?.Justifications,
+    );
+    targetResults.push(
+      justificationId === null
+        ? skippedCliResult(
+            ["justifications", "get", "--id", "<id>"],
+            "No justification id found in the live payload.",
+          )
+        : summarizeOrSkipCliStatus(
+            runCliCommand(
+              ["justifications", "get", "--id", String(justificationId)],
+              env,
+            ),
+            403,
+            "Justification details are disabled or unreadable for this account.",
+          ),
+    );
+
+    const authPhotos = childCommandResults.get(commandKey(["auth", "photos"]));
+    const authPhotoId = findAuthPhotoId(authPhotos.payload?.data);
+
+    targetResults.push(
+      authPhotoId === null
+        ? skippedCliResult(
+            ["auth", "photo", "--id", "<id>"],
+            "No auth photo id found in the live payload.",
+          )
+        : summarizeCliResult(
+            runCliCommand(
+              [
+                "auth",
+                "photo",
+                "--id",
+                String(authPhotoId),
+                "--output",
+                join(downloadDir, "photo-gateway-api-20.jpg"),
+              ],
+              env,
+            ),
+          ),
+    );
+
+    const authTokenInfo = childCommandResults.get(
+      commandKey(["auth", "token-info"]),
+    );
+    const userIdentifier = authTokenInfo.payload?.data?.UserIdentifier;
+
+    targetResults.push(
+      typeof userIdentifier !== "string"
+        ? skippedCliResult(
+            ["auth", "user-info", "--id", "<id>"],
+            "No auth user identifier found in token info.",
+          )
+        : summarizeCliResult(
+            runCliCommand(["auth", "user-info", "--id", userIdentifier], env),
+          ),
+    );
+
+    return {
+      ok: targetResults.every((result) => result.ok),
+      apiBackend: "gateway_api_20",
+      availableChildren: [summarizeChild(GATEWAY_API_20_CHILD)],
+      targetChildren: [summarizeChild(GATEWAY_API_20_CHILD)],
+      results: targetResults,
+    };
+  } finally {
+    rmSync(downloadDir, { recursive: true, force: true });
+  }
+}
+
 export function runCliMatrix(env = process.env) {
+  if (isGatewayApi20Mode(env)) {
+    return runGatewayApi20CliMatrix(env);
+  }
+
   const childrenResult = runCliCommand(["children", "list"], env);
   const results = [summarizeCliResult(childrenResult)];
 

--- a/test/integration/helpers/sdk.mjs
+++ b/test/integration/helpers/sdk.mjs
@@ -2,7 +2,12 @@ import assert from "node:assert/strict";
 import { accessSync, constants } from "node:fs";
 import { fileURLToPath } from "node:url";
 
-import { selectTargetChildren, summarizeChild } from "./children.mjs";
+import {
+  GATEWAY_API_20_CHILD,
+  isGatewayApi20Mode,
+  selectTargetChildren,
+  summarizeChild,
+} from "./children.mjs";
 import { serializeError } from "./errors.mjs";
 
 const sdkEntryUrl = new URL("../../../dist/sdk/index.js", import.meta.url);
@@ -86,6 +91,15 @@ function assertApi3Url(payload) {
   );
 }
 
+function assertGatewayApi2Url(payload) {
+  assert.equal(
+    typeof payload.Url === "string" &&
+      payload.Url.startsWith("https://synergia.librus.pl/gateway/api/2.0/"),
+    true,
+    `Expected synergia.librus.pl gateway API 2.0 URL, got ${payload.Url}`,
+  );
+}
+
 function summarizeApi3ArrayResponse(payload, key) {
   assertApi3Url(payload);
   return summarizeArrayResponse(payload, key);
@@ -93,6 +107,16 @@ function summarizeApi3ArrayResponse(payload, key) {
 
 function summarizeApi3CountResponse(payload, key) {
   assertApi3Url(payload);
+  return summarizeCountResponse(payload, key);
+}
+
+function summarizeGatewayApi2ArrayResponse(payload, key) {
+  assertGatewayApi2Url(payload);
+  return summarizeArrayResponse(payload, key);
+}
+
+function summarizeGatewayApi2CountResponse(payload, key) {
+  assertGatewayApi2Url(payload);
   return summarizeCountResponse(payload, key);
 }
 
@@ -761,12 +785,19 @@ async function runTimetableEntryCheck(api) {
 
 async function runMessageDetailCheck(
   api,
-  { allowForbidden = false, expectWiadomosciUrl = false } = {},
+  {
+    allowForbidden = false,
+    expectGatewayApi2Url = false,
+    expectWiadomosciUrl = false,
+    transportLabel = "API 3.0",
+  } = {},
 ) {
   try {
     const payload = await api.listMessages();
     if (expectWiadomosciUrl) {
       assertWiadomosciUrl(payload);
+    } else if (expectGatewayApi2Url) {
+      assertGatewayApi2Url(payload);
     } else {
       assertApi3Url(payload);
     }
@@ -783,6 +814,8 @@ async function runMessageDetailCheck(
     const message = await api.getMessage(messageId);
     if (expectWiadomosciUrl) {
       assertWiadomosciUrl(message);
+    } else if (expectGatewayApi2Url) {
+      assertGatewayApi2Url(message);
     } else {
       assertApi3Url(message);
     }
@@ -797,7 +830,7 @@ async function runMessageDetailCheck(
       return {
         ok: true,
         skipped: true,
-        reason: "API 3.0 messages returned 403 for this child account.",
+        reason: `${transportLabel} messages returned 403 for this child account.`,
       };
     }
 
@@ -822,19 +855,24 @@ async function runWiadomosciUnreadMessagesCheck(api) {
   );
 }
 
-async function runApi3MessagesCheck(api) {
+async function runApi3MessagesCheck(
+  api,
+  { expectGatewayApi2Url = false, transportLabel = "API 3.0" } = {},
+) {
   try {
     const payload = await api.listMessages();
     return {
       ok: true,
-      ...summarizeApi3ArrayResponse(payload, "Messages"),
+      ...(expectGatewayApi2Url
+        ? summarizeGatewayApi2ArrayResponse(payload, "Messages")
+        : summarizeApi3ArrayResponse(payload, "Messages")),
     };
   } catch (error) {
     if (isApiStatus(error, 403)) {
       return {
         ok: true,
         skipped: true,
-        reason: "API 3.0 messages returned 403 for this child account.",
+        reason: `${transportLabel} messages returned 403 for this child account.`,
       };
     }
 
@@ -845,19 +883,24 @@ async function runApi3MessagesCheck(api) {
   }
 }
 
-async function runApi3UnreadMessagesCheck(api) {
+async function runApi3UnreadMessagesCheck(
+  api,
+  { expectGatewayApi2Url = false, transportLabel = "API 3.0" } = {},
+) {
   try {
     const payload = await api.getUnreadMessages();
     return {
       ok: true,
-      ...summarizeApi3CountResponse(payload, "UnreadMessages"),
+      ...(expectGatewayApi2Url
+        ? summarizeGatewayApi2CountResponse(payload, "UnreadMessages")
+        : summarizeApi3CountResponse(payload, "UnreadMessages")),
     };
   } catch (error) {
     if (isApiStatus(error, 403)) {
       return {
         ok: true,
         skipped: true,
-        reason: "API 3.0 unread messages returned 403 for this child account.",
+        reason: `${transportLabel} unread messages returned 403 for this child account.`,
       };
     }
 
@@ -1218,6 +1261,88 @@ const sdkChecks = [
 export async function runSdkMatrix(env = process.env) {
   const { LibrusSession } = await loadSdkModule();
   const session = LibrusSession.fromEnv(env);
+
+  if (isGatewayApi20Mode(env)) {
+    const api = await session.forChild();
+    const checkEntries = await Promise.all(
+      sdkChecks.map(async ({ name, load, summarize }) => {
+        const check = await runCheck(() => load(api), summarize);
+        return [name, check];
+      }),
+    );
+    const behaviourSystemProposal = await runBehaviourSystemProposalCheck(api);
+    const timetableEntry = await runTimetableEntryCheck(api);
+    const lessonDetail = await runLessonDetailCheck(api);
+    const plannedLessonDetail = await runPlannedLessonDetailCheck(api);
+    const plannedLessonAttachment = await runPlannedLessonAttachmentCheck(api);
+    const realizationDetail = await runRealizationDetailCheck(api);
+    const justifications = await runJustificationsListCheck(api);
+    const justificationDetail = await runJustificationDetailCheck(api);
+    const authPhotoDetail = await runAuthPhotoDetailCheck(api);
+    const authUserInfo = await runAuthUserInfoCheck(api);
+    const authClassroom = await runAuthClassroomCheck(api);
+    const messages = await runApi3MessagesCheck(api, {
+      expectGatewayApi2Url: true,
+      transportLabel: "Gateway API 2.0",
+    });
+    const unreadMessages = await runApi3UnreadMessagesCheck(api, {
+      expectGatewayApi2Url: true,
+      transportLabel: "Gateway API 2.0",
+    });
+    const messageDetail = await runMessageDetailCheck(api, {
+      allowForbidden: true,
+      expectGatewayApi2Url: true,
+      transportLabel: "Gateway API 2.0",
+    });
+    const messageReceiverGroupDetail =
+      await runMessageReceiverGroupDetailCheck(api);
+    const schoolNoticeDetail = await runSchoolNoticeDetailCheck(api);
+    const noteDetail = await runNoteDetailCheck(api);
+    const schoolById = await runSchoolByIdCheck(api);
+    const subjectDetail = await runSubjectDetailCheck(api);
+    const userDetail = await runUserDetailCheck(api);
+    const homeworkAssignmentAttachment =
+      await runHomeworkAssignmentAttachmentCheck(api);
+    const checks = Object.fromEntries([
+      ...checkEntries,
+      ["behaviourSystemProposal", behaviourSystemProposal],
+      ["timetableEntry", timetableEntry],
+      ["lessonDetail", lessonDetail],
+      ["plannedLessonDetail", plannedLessonDetail],
+      ["plannedLessonAttachment", plannedLessonAttachment],
+      ["realizationDetail", realizationDetail],
+      ["justifications", justifications],
+      ["justificationDetail", justificationDetail],
+      ["authPhotoDetail", authPhotoDetail],
+      ["authUserInfo", authUserInfo],
+      ["authClassroom", authClassroom],
+      ["messages", messages],
+      ["unreadMessages", unreadMessages],
+      ["messageDetail", messageDetail],
+      ["messageReceiverGroupDetail", messageReceiverGroupDetail],
+      ["schoolNoticeDetail", schoolNoticeDetail],
+      ["noteDetail", noteDetail],
+      ["schoolById", schoolById],
+      ["subjectDetail", subjectDetail],
+      ["userDetail", userDetail],
+      ["homeworkAssignmentAttachment", homeworkAssignmentAttachment],
+    ]);
+    const child = {
+      ...GATEWAY_API_20_CHILD,
+      ok: Object.values(checks).every((check) => check.ok),
+      checks,
+    };
+
+    return {
+      ok: child.ok,
+      apiBackend: "gateway_api_20",
+      availableChildren: [summarizeChild(GATEWAY_API_20_CHILD)],
+      targetChildren: [summarizeChild(GATEWAY_API_20_CHILD)],
+      childCount: 1,
+      children: [child],
+    };
+  }
+
   const linkedChildren = await session.listChildren();
   const targetChildren = selectTargetChildren(linkedChildren, env);
 

--- a/test/librus-session.test.ts
+++ b/test/librus-session.test.ts
@@ -74,9 +74,20 @@ function readSessionCredentials(session: LibrusSession): {
 } {
   return (
     session as unknown as {
-      credentials: { email: string; password: string };
+      portalCredentials: { email: string; password: string };
     }
-  ).credentials;
+  ).portalCredentials;
+}
+
+function readGatewayCredentials(session: LibrusSession): {
+  login: string;
+  password: string;
+} {
+  return (
+    session as unknown as {
+      gatewayCredentials: { login: string; password: string };
+    }
+  ).gatewayCredentials;
 }
 
 function readPortalClientRequestTimeoutMs(session: LibrusSession): number {
@@ -110,6 +121,41 @@ function captureConfigurationError(
   throw new Error("Expected LibrusConfigurationError to be thrown.");
 }
 
+function captureDeprecationWarnings<T>(callback: () => T): {
+  result: T;
+  warnings: Parameters<typeof process.emitWarning>[];
+} {
+  const emitWarning = vi
+    .spyOn(process, "emitWarning")
+    .mockImplementation(() => undefined);
+
+  try {
+    return {
+      result: callback(),
+      warnings: emitWarning.mock.calls,
+    };
+  } finally {
+    emitWarning.mockRestore();
+  }
+}
+
+function expectDeprecationWarning(
+  warnings: Parameters<typeof process.emitWarning>[],
+  code: string,
+): void {
+  expect(warnings).toEqual(
+    expect.arrayContaining([
+      expect.arrayContaining([
+        expect.any(String),
+        expect.objectContaining({
+          code,
+          type: "DeprecationWarning",
+        }),
+      ]),
+    ]),
+  );
+}
+
 function withTemporaryPortalEnv<T>(
   env: Partial<
     Record<
@@ -117,7 +163,13 @@ function withTemporaryPortalEnv<T>(
       | "LIBRUS_PASSWORD"
       | "LIBRUS_PORTAL_EMAIL"
       | "LIBRUS_PORTAL_PASSWORD"
-      | "LIBRUS_TIMEOUT_MS",
+      | "LIBRUS_TIMEOUT_MS"
+      | "LIBRUS_API_BACKEND"
+      | "LIBRUS_AUTH_MODE"
+      | "LIBRUS_GATEWAY_LOGIN"
+      | "LIBRUS_GATEWAY_PASSWORD"
+      | "SYNERGIA_ID"
+      | "SYNERGIA_PASSWORD",
       string | undefined
     >
   >,
@@ -129,6 +181,12 @@ function withTemporaryPortalEnv<T>(
     LIBRUS_PORTAL_EMAIL: process.env.LIBRUS_PORTAL_EMAIL,
     LIBRUS_PORTAL_PASSWORD: process.env.LIBRUS_PORTAL_PASSWORD,
     LIBRUS_TIMEOUT_MS: process.env.LIBRUS_TIMEOUT_MS,
+    LIBRUS_API_BACKEND: process.env.LIBRUS_API_BACKEND,
+    LIBRUS_AUTH_MODE: process.env.LIBRUS_AUTH_MODE,
+    LIBRUS_GATEWAY_LOGIN: process.env.LIBRUS_GATEWAY_LOGIN,
+    LIBRUS_GATEWAY_PASSWORD: process.env.LIBRUS_GATEWAY_PASSWORD,
+    SYNERGIA_ID: process.env.SYNERGIA_ID,
+    SYNERGIA_PASSWORD: process.env.SYNERGIA_PASSWORD,
   };
 
   for (const [key, value] of Object.entries(env)) {
@@ -161,8 +219,11 @@ describe("LibrusSession.fromEnv", () => {
       LIBRUS_PASSWORD: "compat-secret",
       LIBRUS_PORTAL_EMAIL: "portal@example.com",
       LIBRUS_PORTAL_PASSWORD: "portal-secret",
+      LIBRUS_GATEWAY_LOGIN: "1234567",
+      LIBRUS_GATEWAY_PASSWORD: "gateway-secret",
     });
 
+    expect(session.getApiBackend()).toBe("api_v3");
     expect(readSessionCredentials(session)).toEqual({
       email: "portal@example.com",
       password: "portal-secret",
@@ -170,14 +231,253 @@ describe("LibrusSession.fromEnv", () => {
   });
 
   it("falls back to compatibility environment variables", () => {
-    const session = LibrusSession.fromEnv({
-      LIBRUS_EMAIL: "compat@example.com",
-      LIBRUS_PASSWORD: "compat-secret",
-    });
+    const { result: session, warnings } = captureDeprecationWarnings(() =>
+      LibrusSession.fromEnv({
+        LIBRUS_EMAIL: "compat@example.com",
+        LIBRUS_PASSWORD: "compat-secret",
+      }),
+    );
 
+    expectDeprecationWarning(warnings, "LIBRUS_EMAIL_ENV_DEPRECATED");
+    expectDeprecationWarning(warnings, "LIBRUS_PASSWORD_ENV_DEPRECATED");
+
+    expect(session.getApiBackend()).toBe("api_v3");
     expect(readSessionCredentials(session)).toEqual({
       email: "compat@example.com",
       password: "compat-secret",
+    });
+  });
+
+  it("uses gateway credentials when portal credentials are absent", () => {
+    const session = LibrusSession.fromEnv({
+      LIBRUS_GATEWAY_LOGIN: "1234567",
+      LIBRUS_GATEWAY_PASSWORD: "gateway-secret",
+    });
+
+    expect(session.getApiBackend()).toBe("gateway_api_20");
+    expect(readGatewayCredentials(session)).toEqual({
+      login: "1234567",
+      password: "gateway-secret",
+    });
+  });
+
+  it("lets portal credentials win when both backends are configured", () => {
+    const session = LibrusSession.fromEnv({
+      LIBRUS_PORTAL_EMAIL: "portal@example.com",
+      LIBRUS_PORTAL_PASSWORD: "portal-secret",
+      LIBRUS_GATEWAY_LOGIN: "1234567",
+      LIBRUS_GATEWAY_PASSWORD: "gateway-secret",
+    });
+
+    expect(session.getApiBackend()).toBe("api_v3");
+    expect(readSessionCredentials(session)).toEqual({
+      email: "portal@example.com",
+      password: "portal-secret",
+    });
+  });
+
+  it("lets LIBRUS_API_BACKEND select gateway_api_20 when both backends are configured", () => {
+    const session = LibrusSession.fromEnv({
+      LIBRUS_API_BACKEND: "gateway_api_20",
+      LIBRUS_PORTAL_EMAIL: "portal@example.com",
+      LIBRUS_PORTAL_PASSWORD: "portal-secret",
+      LIBRUS_GATEWAY_LOGIN: "1234567",
+      LIBRUS_GATEWAY_PASSWORD: "gateway-secret",
+    });
+
+    expect(session.getApiBackend()).toBe("gateway_api_20");
+    expect(readGatewayCredentials(session)).toEqual({
+      login: "1234567",
+      password: "gateway-secret",
+    });
+  });
+
+  it("lets LIBRUS_API_BACKEND win over the compatibility auth mode alias", () => {
+    const { result: session, warnings } = captureDeprecationWarnings(() =>
+      LibrusSession.fromEnv({
+        LIBRUS_API_BACKEND: "api_v3",
+        LIBRUS_AUTH_MODE: "synergia",
+        LIBRUS_PORTAL_EMAIL: "portal@example.com",
+        LIBRUS_PORTAL_PASSWORD: "portal-secret",
+        LIBRUS_GATEWAY_LOGIN: "1234567",
+        LIBRUS_GATEWAY_PASSWORD: "gateway-secret",
+      }),
+    );
+
+    expectDeprecationWarning(warnings, "LIBRUS_AUTH_MODE_ENV_DEPRECATED");
+    expect(session.getApiBackend()).toBe("api_v3");
+    expect(readSessionCredentials(session)).toEqual({
+      email: "portal@example.com",
+      password: "portal-secret",
+    });
+  });
+
+  it("accepts the compatibility auth mode alias when LIBRUS_API_BACKEND is unset", () => {
+    const session = LibrusSession.fromEnv({
+      LIBRUS_AUTH_MODE: "synergia",
+      LIBRUS_PORTAL_EMAIL: "portal@example.com",
+      LIBRUS_PORTAL_PASSWORD: "portal-secret",
+      LIBRUS_GATEWAY_LOGIN: "1234567",
+      LIBRUS_GATEWAY_PASSWORD: "gateway-secret",
+    });
+
+    expect(session.getApiBackend()).toBe("gateway_api_20");
+    expect(readGatewayCredentials(session)).toEqual({
+      login: "1234567",
+      password: "gateway-secret",
+    });
+  });
+
+  it("accepts legacy Synergia credential env aliases for gateway_api_20", () => {
+    const { result: session, warnings } = captureDeprecationWarnings(() =>
+      LibrusSession.fromEnv({
+        SYNERGIA_ID: "1234567",
+        SYNERGIA_PASSWORD: "gateway-secret",
+      }),
+    );
+
+    expectDeprecationWarning(warnings, "SYNERGIA_ID_ENV_DEPRECATED");
+    expectDeprecationWarning(warnings, "SYNERGIA_PASSWORD_ENV_DEPRECATED");
+    expect(session.getApiBackend()).toBe("gateway_api_20");
+    expect(readGatewayCredentials(session)).toEqual({
+      login: "1234567",
+      password: "gateway-secret",
+    });
+  });
+
+  it("keeps fromSynergiaCredentials as a compatibility alias", () => {
+    const { result: session, warnings } = captureDeprecationWarnings(() =>
+      LibrusSession.fromSynergiaCredentials({
+        id: "1234567",
+        password: "gateway-secret",
+      }),
+    );
+
+    expectDeprecationWarning(
+      warnings,
+      "LIBRUS_FROM_SYNERGIA_CREDENTIALS_DEPRECATED",
+    );
+    expect(session.getApiBackend()).toBe("gateway_api_20");
+    expect(readGatewayCredentials(session)).toEqual({
+      login: "1234567",
+      password: "gateway-secret",
+    });
+  });
+
+  it("keeps getAuthMode as a compatibility alias with a warning", () => {
+    const session = LibrusSession.fromEnv({
+      LIBRUS_PORTAL_EMAIL: "portal@example.com",
+      LIBRUS_PORTAL_PASSWORD: "portal-secret",
+    });
+
+    const { result: authMode, warnings } = captureDeprecationWarnings(() =>
+      session.getAuthMode(),
+    );
+
+    expect(authMode).toBe("portal");
+    expectDeprecationWarning(warnings, "LIBRUS_GET_AUTH_MODE_DEPRECATED");
+  });
+
+  it("accepts id-shaped gateway credentials in the constructor as a deprecated alias", () => {
+    const { result: session, warnings } = captureDeprecationWarnings(
+      () =>
+        new LibrusSession({
+          apiBackend: "gateway_api_20",
+          credentials: {
+            id: "1234567",
+            password: "gateway-secret",
+          },
+        }),
+    );
+
+    expect(session.getApiBackend()).toBe("gateway_api_20");
+    expect(readGatewayCredentials(session)).toEqual({
+      login: "1234567",
+      password: "gateway-secret",
+    });
+    expectDeprecationWarning(
+      warnings,
+      "LIBRUS_SYNERGIA_CREDENTIALS_ID_DEPRECATED",
+    );
+  });
+
+  it("rejects gateway credentials in api_v3 sessions", () => {
+    const error = captureConfigurationError(
+      () =>
+        new LibrusSession({
+          apiBackend: "api_v3",
+          credentials: {
+            login: "1234567",
+            password: "gateway-secret",
+          },
+        }),
+    );
+
+    expect(error).toMatchObject({
+      code: "CONFIGURATION_ERROR",
+      message: "api_v3 credentials require email and password.",
+    });
+  });
+
+  it("rejects portal credentials in gateway_api_20 sessions", () => {
+    const error = captureConfigurationError(
+      () =>
+        new LibrusSession({
+          apiBackend: "gateway_api_20",
+          credentials: {
+            email: "portal@example.com",
+            password: "portal-secret",
+          },
+        }),
+    );
+
+    expect(error).toMatchObject({
+      code: "CONFIGURATION_ERROR",
+      message: "gateway_api_20 credentials require login and password.",
+    });
+  });
+
+  it("does not treat deprecated LIBRUS_EMAIL as a Synergia id", () => {
+    const session = LibrusSession.fromEnv({
+      LIBRUS_EMAIL: "1234567",
+      LIBRUS_PASSWORD: "compat-secret",
+    });
+
+    expect(session.getApiBackend()).toBe("api_v3");
+    expect(readSessionCredentials(session)).toEqual({
+      email: "1234567",
+      password: "compat-secret",
+    });
+  });
+
+  it("reports missing gateway credentials when gateway_api_20 is explicit", () => {
+    const error = captureConfigurationError(() =>
+      LibrusSession.fromEnv({
+        LIBRUS_API_BACKEND: "gateway_api_20",
+        LIBRUS_GATEWAY_LOGIN: "1234567",
+      }),
+    );
+
+    expect(error).toMatchObject({
+      code: "CONFIGURATION_ERROR",
+      message:
+        "Missing gateway API 2.0 credentials. Password: LIBRUS_GATEWAY_PASSWORD is unset.",
+    });
+  });
+
+  it("fails when LIBRUS_API_BACKEND is invalid", () => {
+    const error = captureConfigurationError(() =>
+      LibrusSession.fromEnv({
+        LIBRUS_API_BACKEND: "synergia",
+        LIBRUS_PORTAL_EMAIL: "portal@example.com",
+        LIBRUS_PORTAL_PASSWORD: "portal-secret",
+      }),
+    );
+
+    expect(error).toMatchObject({
+      code: "CONFIGURATION_ERROR",
+      message:
+        'Invalid LIBRUS_API_BACKEND. Expected "api_v3" or "gateway_api_20".',
     });
   });
 
@@ -292,6 +592,30 @@ describe("LibrusSession.fromEnv", () => {
 });
 
 describe("LibrusSession.resolveChild", () => {
+  it("rejects portal-only child discovery in gateway_api_20", async () => {
+    const session = LibrusSession.fromGatewayCredentials({
+      login: "1234567",
+      password: "gateway-secret",
+    });
+
+    await expect(session.listChildren()).rejects.toMatchObject({
+      code: "UNSUPPORTED_BACKEND",
+      details: { apiBackend: "gateway_api_20" },
+    });
+  });
+
+  it("rejects explicit child selection in gateway_api_20", async () => {
+    const session = LibrusSession.fromGatewayCredentials({
+      login: "1234567",
+      password: "gateway-secret",
+    });
+
+    await expect(session.forChild("101")).rejects.toMatchObject({
+      code: "UNSUPPORTED_BACKEND",
+      details: { apiBackend: "gateway_api_20" },
+    });
+  });
+
   it("matches child by id first", async () => {
     const { portalClient } = createPortalClientStub({
       accounts: [

--- a/test/verify-published-package.test.ts
+++ b/test/verify-published-package.test.ts
@@ -1,13 +1,38 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import * as publishedPackageModule from "../scripts/verify-published-package.mjs";
+
+const { execFileSync } = vi.hoisted(() => ({
+  execFileSync: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+  execFileSync,
+}));
 
 const { assertPublishedPackageSecurityMetadata } = publishedPackageModule as {
   assertPublishedPackageSecurityMetadata: (
     metadata: unknown,
     packageSpec: string,
   ) => void;
+  fetchPublishedPackageMetadata: (packageSpec: string) => string;
+  verifyPublishedPackage: (
+    packageName: string,
+    packageVersion?: string,
+  ) => void;
 };
+const { fetchPublishedPackageMetadata, verifyPublishedPackage } =
+  publishedPackageModule as {
+    fetchPublishedPackageMetadata: (packageSpec: string) => string;
+    verifyPublishedPackage: (
+      packageName: string,
+      packageVersion?: string,
+    ) => void;
+  };
+
+beforeEach(() => {
+  execFileSync.mockReset();
+});
 
 describe("assertPublishedPackageSecurityMetadata", () => {
   it("accepts published packages with attestations, provenance, and signatures", () => {
@@ -71,5 +96,87 @@ describe("assertPublishedPackageSecurityMetadata", () => {
         "librus-sdk@0.3.3",
       ),
     ).toThrow("missing provenance details");
+  });
+
+  it("fails when npm returns no metadata object", () => {
+    expect(() =>
+      assertPublishedPackageSecurityMetadata(null, "librus-sdk@0.3.3"),
+    ).toThrow("npm view returned no package metadata");
+  });
+});
+
+describe("fetchPublishedPackageMetadata", () => {
+  it("fetches package metadata through npm view", () => {
+    execFileSync.mockReturnValue('{"name":"librus-sdk"}');
+
+    const stdout = fetchPublishedPackageMetadata("librus-sdk@0.3.3");
+
+    expect(stdout).toBe('{"name":"librus-sdk"}');
+    expect(execFileSync).toHaveBeenCalledWith(
+      "npm",
+      ["view", "librus-sdk@0.3.3", "--json"],
+      {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+  });
+
+  it("wraps npm view failures", () => {
+    execFileSync.mockImplementation(() => {
+      throw new Error("registry unavailable");
+    });
+
+    expect(() => fetchPublishedPackageMetadata("librus-sdk@0.3.3")).toThrow(
+      "Failed to fetch package metadata for librus-sdk@0.3.3 from npm registry: registry unavailable",
+    );
+  });
+});
+
+describe("verifyPublishedPackage", () => {
+  it("verifies a specific package version", () => {
+    execFileSync.mockReturnValue(
+      JSON.stringify({
+        dist: {
+          attestations: {
+            url: "https://registry.npmjs.org/-/npm/v1/attestations/librus-sdk@0.3.3",
+            provenance: {
+              predicateType: "https://slsa.dev/provenance/v1",
+            },
+          },
+          signatures: [{ keyid: "abc", sig: "def" }],
+        },
+      }),
+    );
+
+    expect(() => verifyPublishedPackage("librus-sdk", "0.3.3")).not.toThrow();
+    expect(execFileSync).toHaveBeenCalledWith(
+      "npm",
+      ["view", "librus-sdk@0.3.3", "--json"],
+      expect.any(Object),
+    );
+  });
+
+  it("verifies the latest package when version is omitted", () => {
+    execFileSync.mockReturnValue(
+      JSON.stringify({
+        dist: {
+          attestations: {
+            url: "https://registry.npmjs.org/-/npm/v1/attestations/librus-sdk",
+            provenance: {
+              predicateType: "https://slsa.dev/provenance/v1",
+            },
+          },
+          signatures: [{ keyid: "abc", sig: "def" }],
+        },
+      }),
+    );
+
+    expect(() => verifyPublishedPackage("librus-sdk")).not.toThrow();
+    expect(execFileSync).toHaveBeenCalledWith(
+      "npm",
+      ["view", "librus-sdk", "--json"],
+      expect.any(Object),
+    );
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,10 @@ export default defineConfig({
     coverage: {
       provider: "v8",
       thresholds: {
-        branches: 84,
+        statements: 93,
+        branches: 85,
+        functions: 95,
+        lines: 93,
       },
     },
     include: ["test/**/*.test.ts"],


### PR DESCRIPTION
## Summary

- Split the high-level session model into explicit `api_v3` and `gateway_api_20` backends while keeping existing Portal users on API v3 by default.
- Add Gateway API 2.0 credentials, auto-detection, optional `LIBRUS_CHILD` for API v3 CLI commands, and unsupported-child-selector handling for gateway sessions.
- Rename the gateway auth/session APIs to `GatewayApi20AuthClient` and `fromGatewayCredentials()` while keeping deprecated compatibility aliases with Node deprecation warnings.
- Update README, CHANGELOG, AGENTS guidance, integration helpers, and the saved architecture task notes.

## Validation

- `npm run lint`
- `npm test`
- `npm run build`
- Gateway live smoke via local env file with secret-safe output only

## Notes

Unrelated untracked `.tasks/rearchitect/*` and older task-plan files were left out of this PR.