### PR TITLE
[codex] Release 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-05-18
+
 ### Added
 
 - Gateway API 2.0 login/password authentication through

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.3",
   "info": {
     "title": "Librus Synergia API (SDK-supported subset)",
-    "version": "0.6.2",
+    "version": "0.7.0",
     "description": "Best-effort OpenAPI document generated from the SDK's supported child-scoped Synergia GET surface. Authentication starts on portal.librus.pl; this document covers the subsequent bearer-token calls against api.librus.pl/3.0."
   },
   "servers": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "librus-sdk",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "librus-sdk",
-      "version": "0.6.2",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@valibot/to-json-schema": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librus-sdk",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "description": "TypeScript SDK and CLI for Librus family portal and Gateway API 2.0 flows.",
   "author": "Andrey Koltsov",
   "repository": {


### PR DESCRIPTION
## Summary

- bump package version to 0.7.0
- move Gateway API 2.0 release notes from Unreleased into the 0.7.0 changelog section
- regenerate openapi.json for version 0.7.0

## Validation

- npm run validate