### PR TITLE
Fix Scorecard workflow permissions

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -15,6 +15,7 @@ jobs:
     name: Scorecard analysis
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       security-events: write
       id-token: write
 
@@ -31,8 +32,18 @@ jobs:
           results_format: sarif
           publish_results: true
 
-      - name: Upload Scorecard artifact
+      - name: Check Scorecard SARIF output
+        id: scorecard-sarif
         if: always()
+        run: |
+          if [ -f scorecard-results.sarif ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload Scorecard artifact
+        if: always() && steps.scorecard-sarif.outputs.exists == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: scorecard-results
@@ -40,7 +51,7 @@ jobs:
           retention-days: 5
 
       - name: Upload Scorecard results to code scanning
-        if: always()
+        if: always() && steps.scorecard-sarif.outputs.exists == 'true'
         uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
         with:
           sarif_file: scorecard-results.sarif


### PR DESCRIPTION
## Summary
- grant the Scorecard job explicit contents: read access so checkout can fetch the repository
- skip artifact and SARIF upload steps when Scorecard did not produce the SARIF file, avoiding secondary missing-file failures

## Verification
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/scorecard.yml"); puts "yaml ok"'