### PR TITLE
[codex] add logging hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Generated OpenAPI documents for the supported `gateway_api_20` and
   `wiadomosci.librus.pl/api` surfaces.
+- Secret-safe SDK logging hooks for Portal login and Synergia request lifecycle
+  events, plus CLI `--verbose` and `LIBRUS_LOG_LEVEL` stderr diagnostics.
 
 ## [0.7.1] - 2026-05-20
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ these variables:
 | `LIBRUS_GATEWAY_PASSWORD` | `gateway_api_20` | Password for the Gateway API 2.0 login.                            |
 | `LIBRUS_CHILD`            | No               | Optional default child id or login for `api_v3` CLI commands.      |
 | `LIBRUS_TIMEOUT_MS`       | No               | Positive integer request timeout in milliseconds.                  |
+| `LIBRUS_LOG_LEVEL`        | No               | Optional CLI SDK log level: `debug`, `info`, `warn`, or `error`.   |
 
 If no timeout is configured, portal and child-scoped SDK requests default to
 `30000` milliseconds. Invalid timeout values fail fast with
@@ -117,6 +118,7 @@ import {
   generateWiadomosciOpenApiDocument,
   LibrusSdkError,
   type LibrusApiBackend,
+  type Logger,
 } from "librus-sdk";
 ```
 
@@ -127,6 +129,7 @@ import {
 | `GatewayApi20AuthClient`              | Lower-level Gateway API 2.0 login/password auth client for `synergia.librus.pl/gateway/api/2.0` cookie-backed requests.               |
 | `PortalClient`                        | Lower-level portal session client for `portal.librus.pl` login, `/Me`, and `/SynergiaAccounts`.                                       |
 | `SynergiaApiClient`                   | Child-scoped GET client for the supported `https://api.librus.pl/3.0` surface when you already have a bearer token.                   |
+| `Logger`                              | Minimal structured logging interface accepted by SDK clients and sessions.                                                            |
 | `generateOpenApiDocument`             | Generates the shipped OpenAPI document for the supported `api_v3` child-scoped GET subset.                                            |
 | `generateGatewayApi20OpenApiDocument` | Generates the shipped OpenAPI document for the supported `gateway_api_20` GET subset.                                                 |
 | `generateWiadomosciOpenApiDocument`   | Generates the shipped OpenAPI document for the supported `wiadomosci.librus.pl/api` inbox subset.                                     |
@@ -142,6 +145,26 @@ const client = await session.forChild(children[0]);
 const grades = await client.getGrades();
 console.log(grades);
 ```
+
+Custom logger:
+
+```ts
+import { LibrusSession, type Logger } from "librus-sdk";
+import pino from "pino";
+
+const pinoLogger = pino();
+const logger: Logger = {
+  log: (level, event, fields) => pinoLogger[level]({ event, ...fields }),
+};
+
+const session = LibrusSession.fromEnv(process.env, { logger });
+const client = await session.forChild("child-login");
+await client.getGrades();
+```
+
+SDK logs are structured and secret-safe. They include request URLs, status,
+durations, auth mode, and stable error codes, but never include passwords,
+bearer tokens, cookie values, request bodies, or response bodies.
 
 Gateway API 2.0 flow:
 
@@ -171,9 +194,9 @@ with `UNSUPPORTED_BACKEND` in `gateway_api_20`.
 
 Current high-level methods on `LibrusSession`:
 
-- `LibrusSession.fromEnv(env?)`
+- `LibrusSession.fromEnv(env?, options?)`
 - `LibrusSession.fromGatewayCredentials(credentials, options?)`
-- `new LibrusSession({ apiBackend?, credentials, portalClient?, portalClientOptions?, gatewayApi20AuthClient?, gatewayApi20AuthClientOptions?, bffClientOptions?, synergiaClientOptions?, wiadomosciClientOptions?, requestTimeoutMs? })`
+- `new LibrusSession({ apiBackend?, credentials, portalClient?, portalClientOptions?, gatewayApi20AuthClient?, gatewayApi20AuthClientOptions?, bffClientOptions?, synergiaClientOptions?, wiadomosciClientOptions?, requestTimeoutMs?, logger? })`
 - `login()`
 - `getApiBackend()`
 - `getPortalMe()`
@@ -311,6 +334,7 @@ Root CLI commands:
 
 - `librus-sdk --help`
 - `librus-sdk --version`
+- `librus-sdk --verbose <command>`
 
 Every leaf command supports `--format <text|json>`. In `api_v3`, child-scoped
 commands require a child selector: pass `--child <id-or-login>` or set
@@ -319,6 +343,10 @@ account is already child-scoped, so the same commands run without `--child` and
 explicit `--child` fails with `UNSUPPORTED_BACKEND`. Portal-only commands such
 as `children list`, `messages bff-list`, and `messages wiadomosci-list` are not
 available in `gateway_api_20`.
+
+`--verbose` enables debug-level SDK diagnostics on stderr. `LIBRUS_LOG_LEVEL`
+can enable diagnostics without a flag and filters by minimum level. Successful
+command payloads still go to stdout, so `--format json` remains machine-readable.
 
 | Family           | Subcommands                                                                                                 | Extra selectors and flags                                                                                                                                                                          |
 | ---------------- | ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/src/cli/commands/common.ts
+++ b/src/cli/commands/common.ts
@@ -4,6 +4,7 @@ import { InvalidArgumentError, type Command } from "commander";
 import {
   LibrusSession,
   LibrusSdkError,
+  type Logger,
   type ChildAccount,
   type ChildAccountSummary,
   type LibrusApiBackend,
@@ -33,7 +34,7 @@ export interface CliOutput {
 export interface CliContext {
   stdout: CliOutput;
   stderr: CliOutput;
-  createSession: () => LibrusSession;
+  createSession: (logger?: Logger) => LibrusSession;
   outputWidth?: number;
   writeFile?: (path: string, data: Uint8Array) => void;
 }

--- a/src/cli/logger.ts
+++ b/src/cli/logger.ts
@@ -1,0 +1,90 @@
+import {
+  LibrusConfigurationError,
+  type Logger,
+  type LogLevel,
+} from "../sdk/index.js";
+import type { CliOutput } from "./commands/common.js";
+
+const LOG_LEVELS: LogLevel[] = ["debug", "info", "warn", "error"];
+const LOG_LEVEL_PRIORITY: Record<LogLevel, number> = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+};
+
+export function createCliLogger(
+  output: CliOutput,
+  minimumLevel: LogLevel,
+): Logger {
+  return {
+    log(level, event, fields = {}) {
+      if (LOG_LEVEL_PRIORITY[level] < LOG_LEVEL_PRIORITY[minimumLevel]) {
+        return;
+      }
+
+      output.write(
+        `${new Date().toISOString()} ${level.toUpperCase()} ${event}${formatFields(fields)}\n`,
+      );
+    },
+  };
+}
+
+export function resolveCliLogLevel(
+  argv: string[],
+  env: NodeJS.ProcessEnv = process.env,
+): LogLevel | undefined {
+  if (argv.includes("--verbose")) {
+    return "debug";
+  }
+
+  const rawLogLevel = env.LIBRUS_LOG_LEVEL;
+
+  if (rawLogLevel === undefined) {
+    return undefined;
+  }
+
+  const logLevel = rawLogLevel.trim().toLowerCase();
+
+  if (isLogLevel(logLevel)) {
+    return logLevel;
+  }
+
+  throw new LibrusConfigurationError(
+    'Invalid LIBRUS_LOG_LEVEL. Expected "debug", "info", "warn", or "error".',
+  );
+}
+
+function isLogLevel(value: string): value is LogLevel {
+  return LOG_LEVELS.includes(value as LogLevel);
+}
+
+function formatFields(fields: Record<string, unknown>): string {
+  const entries = Object.entries(fields).filter(
+    ([, value]) => value !== undefined,
+  );
+
+  if (entries.length === 0) {
+    return "";
+  }
+
+  return ` ${entries
+    .map(([key, value]) => `${key}=${formatFieldValue(value)}`)
+    .join(" ")}`;
+}
+
+function formatFieldValue(value: unknown): string {
+  if (
+    value === null ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return String(value);
+  }
+
+  if (typeof value === "string") {
+    return JSON.stringify(value);
+  }
+
+  return JSON.stringify(value);
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -26,6 +26,7 @@ import { createMeCommand } from "./commands/me.js";
 import { createNotesCommand } from "./commands/notes.js";
 import { createNotificationsCommand } from "./commands/notifications.js";
 import { createTimetableCommand } from "./commands/timetable.js";
+import { createCliLogger, resolveCliLogLevel } from "./logger.js";
 
 const packageJson = JSON.parse(
   readFileSync(new URL("../../package.json", import.meta.url), "utf8"),
@@ -39,7 +40,10 @@ export function createDefaultCliContext(): CliContext {
     stderr: {
       write: (chunk) => process.stderr.write(chunk),
     },
-    createSession: () => LibrusSession.fromEnv(),
+    createSession: (logger) =>
+      logger === undefined
+        ? LibrusSession.fromEnv()
+        : LibrusSession.fromEnv(process.env, { logger }),
     outputWidth: process.stdout.columns ?? 80,
     writeFile: (path, data) => writeFileSync(path, data),
   };
@@ -50,7 +54,8 @@ export function createProgram(context: CliContext): Command {
     new Command()
       .name("librus-sdk")
       .description("CLI for the Librus family portal flow")
-      .version(packageJson.version),
+      .version(packageJson.version)
+      .option("--verbose", "Write diagnostic logs to stderr"),
     context,
   );
 
@@ -76,19 +81,35 @@ export async function runCli(
   argv = process.argv,
   context = createDefaultCliContext(),
 ): Promise<number> {
-  const program = createProgram(context);
   const userArgs = argv.slice(2);
+  const helpProgram = createProgram(context);
 
   if (
     userArgs.length === 0 ||
     (userArgs.length === 1 &&
       (userArgs[0] === "--help" || userArgs[0] === "-h"))
   ) {
-    context.stdout.write(program.helpInformation());
+    context.stdout.write(helpProgram.helpInformation());
     return 0;
   }
 
   try {
+    const logLevel = isInformationalCliInvocation(userArgs)
+      ? undefined
+      : resolveCliLogLevel(userArgs);
+    const logger =
+      logLevel === undefined
+        ? undefined
+        : createCliLogger(context.stderr, logLevel);
+    const runtimeContext =
+      logger === undefined
+        ? context
+        : {
+            ...context,
+            createSession: () => context.createSession(logger),
+          };
+    const program = createProgram(runtimeContext);
+
     await program.parseAsync(argv);
     return 0;
   } catch (error) {
@@ -117,6 +138,13 @@ export async function runCli(
       ? error.exitCode
       : 1;
   }
+}
+
+function isInformationalCliInvocation(argv: string[]): boolean {
+  return argv.some(
+    (arg) =>
+      arg === "--help" || arg === "-h" || arg === "--version" || arg === "-V",
+  );
 }
 
 export function isCliEntryPoint(

--- a/src/sdk/LibrusSession.ts
+++ b/src/sdk/LibrusSession.ts
@@ -30,6 +30,7 @@ import {
   validateOptionalRequestTimeoutMs,
 } from "./requestTimeout.js";
 import { emitDeprecationWarningOnce } from "./deprecationWarnings.js";
+import type { Logger } from "./logger.js";
 
 type PortalCredentialEnvName =
   | "LIBRUS_EMAIL"
@@ -103,6 +104,7 @@ export interface LibrusSessionOptions {
     "ensurePortalLogin" | "portalClient"
   >;
   requestTimeoutMs?: number;
+  logger?: Logger;
 }
 
 export class LibrusSession {
@@ -154,9 +156,13 @@ export class LibrusSession {
       options.portalClientOptions,
       requestTimeoutMs,
     );
-    const synergiaClientOptions = applyRequestTimeout(
-      options.synergiaClientOptions,
-      requestTimeoutMs,
+    const loggedPortalClientOptions = applyLogger(
+      portalClientOptions,
+      options.logger,
+    );
+    const synergiaClientOptions = applyLogger(
+      applyRequestTimeout(options.synergiaClientOptions, requestTimeoutMs),
+      options.logger,
     );
     const bffClientOptions = applyRequestTimeout(
       options.bffClientOptions,
@@ -175,7 +181,7 @@ export class LibrusSession {
     if (this.apiBackend === "api_v3") {
       this.portalCredentials = normalizePortalCredentials(options.credentials);
       this.portalClient =
-        options.portalClient ?? new PortalClient(portalClientOptions);
+        options.portalClient ?? new PortalClient(loggedPortalClientOptions);
     } else {
       this.gatewayCredentials = normalizeGatewayCredentials(
         options.credentials,
@@ -191,22 +197,34 @@ export class LibrusSession {
     this.wiadomosciClientOptions = wiadomosciClientOptions;
   }
 
-  static fromEnv(env: NodeJS.ProcessEnv = process.env): LibrusSession {
+  static fromEnv(
+    env: NodeJS.ProcessEnv = process.env,
+    options: Omit<
+      LibrusSessionOptions,
+      "apiBackend" | "authMode" | "credentials"
+    > = {},
+  ): LibrusSession {
     const apiBackend = resolveApiBackend(env);
     const requestTimeoutMs = parseRequestTimeoutMsFromEnv(
       env.LIBRUS_TIMEOUT_MS,
     );
-    const options = requestTimeoutMs === undefined ? {} : { requestTimeoutMs };
+    const sessionOptions =
+      requestTimeoutMs === undefined
+        ? options
+        : {
+            ...options,
+            requestTimeoutMs: options.requestTimeoutMs ?? requestTimeoutMs,
+          };
 
     if (apiBackend === "gateway_api_20") {
       return LibrusSession.fromGatewayCredentials(
         resolveGatewayCredentialsFromEnv(env),
-        options,
+        sessionOptions,
       );
     }
 
     return new LibrusSession({
-      ...options,
+      ...sessionOptions,
       apiBackend: "api_v3",
       credentials: resolvePortalCredentialsFromEnv(env),
     });
@@ -737,4 +755,15 @@ function applyRequestTimeout<T extends { requestTimeoutMs?: number }>(
   return options
     ? { ...options, requestTimeoutMs }
     : ({ requestTimeoutMs } as T);
+}
+
+function applyLogger<T extends { logger?: Logger }>(
+  options: T | undefined,
+  logger: Logger | undefined,
+): T | undefined {
+  if (options?.logger !== undefined || logger === undefined) {
+    return options;
+  }
+
+  return options ? { ...options, logger } : ({ logger } as T);
 }

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -1,4 +1,5 @@
 export { BffApiClient } from "./bff/BffApiClient.js";
+export { noopLogger, type Logger, type LogLevel } from "./logger.js";
 export {
   LibrusSession,
   type LibrusApiBackend,

--- a/src/sdk/logger.ts
+++ b/src/sdk/logger.ts
@@ -1,0 +1,48 @@
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+export interface Logger {
+  log(level: LogLevel, event: string, fields?: Record<string, unknown>): void;
+}
+
+export const noopLogger: Logger = {
+  log: () => undefined,
+};
+
+export function getErrorLogFields(error: unknown): Record<string, unknown> {
+  if (error instanceof Error) {
+    const fields: Record<string, unknown> = {
+      errorName: error.name,
+      errorMessage: error.message,
+    };
+
+    if ("code" in error && typeof error.code === "string") {
+      fields.errorCode = error.code;
+    }
+
+    if (
+      "details" in error &&
+      error.details !== null &&
+      typeof error.details === "object"
+    ) {
+      if (
+        "status" in error.details &&
+        typeof error.details.status === "number"
+      ) {
+        fields.status = error.details.status;
+      }
+
+      if (
+        "timeoutMs" in error.details &&
+        typeof error.details.timeoutMs === "number"
+      ) {
+        fields.timeoutMs = error.details.timeoutMs;
+      }
+    }
+
+    return fields;
+  }
+
+  return {
+    errorName: typeof error,
+  };
+}

--- a/src/sdk/portal/PortalClient.ts
+++ b/src/sdk/portal/PortalClient.ts
@@ -13,6 +13,7 @@ import {
   resolveRequestTimeoutMs,
   wrapFetchWithTimeout,
 } from "../requestTimeout.js";
+import { getErrorLogFields, noopLogger, type Logger } from "../logger.js";
 import type { BaseIssue, BaseSchema, InferOutput } from "valibot";
 import {
   portalMeSchema,
@@ -28,6 +29,7 @@ export interface PortalClientOptions {
   loginPath?: string;
   loginActionPath?: string;
   requestTimeoutMs?: number;
+  logger?: Logger;
 }
 
 export class PortalClient {
@@ -37,9 +39,11 @@ export class PortalClient {
   private readonly loginPath: string;
   private readonly loginActionPath: string;
   private readonly requestTimeoutMs: number;
+  private readonly logger: Logger;
   private loggedIn = false;
 
   constructor(options: PortalClientOptions = {}) {
+    this.logger = options.logger ?? noopLogger;
     this.requestTimeoutMs = resolveRequestTimeoutMs(options.requestTimeoutMs);
     const sessionFetch = createSessionFetch(options.fetch ?? fetch);
     this.fetchImpl = wrapFetchWithTimeout(
@@ -55,48 +59,67 @@ export class PortalClient {
   }
 
   async login(credentials: PortalCredentials): Promise<void> {
-    const loginPageUrl = this.buildUrl(this.portalBaseUrl, this.loginPath);
-    const loginPageResponse = await this.fetchImpl(loginPageUrl, {
-      method: "GET",
+    const startedAt = Date.now();
+
+    this.logger.log("debug", "portal.login.start", {
+      portalBaseUrl: this.portalBaseUrl,
     });
-
-    if (!loginPageResponse.ok) {
-      throw new LibrusAuthenticationError();
-    }
-
-    const loginPageHtml = await loginPageResponse.text();
-    const csrfToken = extractPortalCsrfToken(loginPageHtml);
-    const form = new URLSearchParams({
-      email: credentials.email,
-      password: credentials.password,
-      _token: csrfToken,
-    });
-
-    const loginActionResponse = await this.fetchImpl(
-      this.buildUrl(this.portalBaseUrl, this.loginActionPath),
-      {
-        method: "POST",
-        headers: {
-          "content-type": "application/x-www-form-urlencoded",
-          referer: loginPageUrl,
-        },
-        body: form.toString(),
-      },
-    );
-
-    if (!loginActionResponse.ok) {
-      throw new LibrusAuthenticationError();
-    }
 
     try {
-      await this.getMe();
-      this.loggedIn = true;
-    } catch (error) {
-      if (error instanceof LibrusApiError && error.details?.status === 401) {
+      const loginPageUrl = this.buildUrl(this.portalBaseUrl, this.loginPath);
+      const loginPageResponse = await this.fetchImpl(loginPageUrl, {
+        method: "GET",
+      });
+
+      if (!loginPageResponse.ok) {
         throw new LibrusAuthenticationError();
       }
 
-      throw error;
+      const loginPageHtml = await loginPageResponse.text();
+      const csrfToken = extractPortalCsrfToken(loginPageHtml);
+      const form = new URLSearchParams({
+        email: credentials.email,
+        password: credentials.password,
+        _token: csrfToken,
+      });
+
+      const loginActionResponse = await this.fetchImpl(
+        this.buildUrl(this.portalBaseUrl, this.loginActionPath),
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/x-www-form-urlencoded",
+            referer: loginPageUrl,
+          },
+          body: form.toString(),
+        },
+      );
+
+      if (!loginActionResponse.ok) {
+        throw new LibrusAuthenticationError();
+      }
+
+      await this.getMe();
+      this.loggedIn = true;
+      this.logger.log("info", "portal.login.success", {
+        durationMs: Date.now() - startedAt,
+      });
+    } catch (error) {
+      const authError =
+        error instanceof LibrusApiError && error.details?.status === 401
+          ? new LibrusAuthenticationError()
+          : error;
+
+      this.logger.log("error", "portal.login.failure", {
+        durationMs: Date.now() - startedAt,
+        ...getErrorLogFields(authError),
+      });
+
+      if (authError instanceof Error) {
+        throw authError;
+      }
+
+      throw authError;
     }
   }
 

--- a/src/sdk/synergia/SynergiaApiClient.ts
+++ b/src/sdk/synergia/SynergiaApiClient.ts
@@ -207,6 +207,7 @@ import {
   resolveRequestTimeoutMs,
   wrapFetchWithTimeout,
 } from "../requestTimeout.js";
+import { noopLogger, type Logger } from "../logger.js";
 
 export interface SynergiaApiClientOptions {
   fetch?: FetchLike;
@@ -214,6 +215,7 @@ export interface SynergiaApiClientOptions {
   authMode?: SynergiaAuthMode;
   messageBackend?: MessageReadBackend;
   requestTimeoutMs?: number;
+  logger?: Logger;
 }
 
 type SynergiaId = string | number;
@@ -229,10 +231,12 @@ export class SynergiaApiClient {
   private readonly authMode: SynergiaAuthMode;
   private readonly messageBackend: MessageReadBackend | undefined;
   private readonly requestTimeoutMs: number;
+  private readonly logger: Logger;
 
   constructor(accessToken: string, options: SynergiaApiClientOptions = {}) {
     this.accessToken = accessToken;
     this.authMode = options.authMode ?? "bearer";
+    this.logger = options.logger ?? noopLogger;
     this.requestTimeoutMs = resolveRequestTimeoutMs(options.requestTimeoutMs);
     this.fetchImpl = wrapFetchWithTimeout(
       options.fetch ?? fetch,
@@ -257,6 +261,7 @@ export class SynergiaApiClient {
       schema,
       options,
       this.authMode,
+      this.logger,
     );
   }
 
@@ -271,6 +276,7 @@ export class SynergiaApiClient {
       path,
       options,
       this.authMode,
+      this.logger,
     );
   }
 

--- a/src/sdk/synergia/request.ts
+++ b/src/sdk/synergia/request.ts
@@ -1,7 +1,12 @@
 import type { FetchLike } from "../models/common.js";
-import { LibrusApiError, LibrusSdkError } from "../models/errors.js";
+import {
+  LibrusApiError,
+  LibrusNetworkTimeoutError,
+  LibrusSdkError,
+} from "../models/errors.js";
 import type { SynergiaBinaryResult } from "../models/synergia/common.js";
 import { parseApiResponse } from "../validation/responseValidation.js";
+import { getErrorLogFields, noopLogger, type Logger } from "../logger.js";
 import type { BaseIssue, BaseSchema, InferOutput } from "valibot";
 
 export type SynergiaQuery = Record<
@@ -108,20 +113,44 @@ export async function getJson<
   schema: TSchema,
   options: SynergiaRequestOptions = {},
   authMode: SynergiaAuthMode = "bearer",
+  logger: Logger = noopLogger,
 ): Promise<InferOutput<TSchema>> {
   const endpoint = buildEndpoint(apiBaseUrl, path, options.query);
-  const response = await fetchImpl(endpoint, {
+  const startedAt = Date.now();
+  const requestFields = {
+    authMode,
+    endpoint,
     method: "GET",
-    headers: buildSynergiaHeaders(accessToken, authMode, {
-      accept: "application/json",
-    }),
-  });
+    path,
+  };
 
-  if (!response.ok) {
-    await throwForFailure(response, endpoint);
+  logger.log("debug", "synergia.request.start", requestFields);
+
+  try {
+    const response = await fetchImpl(endpoint, {
+      method: "GET",
+      headers: buildSynergiaHeaders(accessToken, authMode, {
+        accept: "application/json",
+      }),
+    });
+
+    if (!response.ok) {
+      await throwForFailure(response, endpoint);
+    }
+
+    const payload = parseApiResponse(schema, await response.json(), endpoint);
+
+    logger.log("info", "synergia.request.success", {
+      ...requestFields,
+      durationMs: Date.now() - startedAt,
+      status: response.status,
+    });
+
+    return payload;
+  } catch (error) {
+    logSynergiaRequestError(logger, error, requestFields, startedAt);
+    throw error;
   }
-
-  return parseApiResponse(schema, await response.json(), endpoint);
 }
 
 export async function getBinary(
@@ -131,20 +160,65 @@ export async function getBinary(
   path: string,
   options: SynergiaRequestOptions = {},
   authMode: SynergiaAuthMode = "bearer",
+  logger: Logger = noopLogger,
 ): Promise<SynergiaBinaryResult> {
   const endpoint = buildEndpoint(apiBaseUrl, path, options.query);
-  const response = await fetchImpl(endpoint, {
+  const startedAt = Date.now();
+  const requestFields = {
+    authMode,
+    endpoint,
     method: "GET",
-    headers: buildSynergiaHeaders(accessToken, authMode),
-  });
+    path,
+  };
 
-  if (!response.ok) {
-    await throwForFailure(response, endpoint);
+  logger.log("debug", "synergia.request.start", requestFields);
+
+  try {
+    const response = await fetchImpl(endpoint, {
+      method: "GET",
+      headers: buildSynergiaHeaders(accessToken, authMode),
+    });
+
+    if (!response.ok) {
+      await throwForFailure(response, endpoint);
+    }
+
+    const result = {
+      data: await response.arrayBuffer(),
+      contentDisposition: response.headers.get("content-disposition"),
+      contentType: response.headers.get("content-type"),
+    };
+
+    logger.log("info", "synergia.request.success", {
+      ...requestFields,
+      durationMs: Date.now() - startedAt,
+      status: response.status,
+    });
+
+    return result;
+  } catch (error) {
+    logSynergiaRequestError(logger, error, requestFields, startedAt);
+    throw error;
+  }
+}
+
+function logSynergiaRequestError(
+  logger: Logger,
+  error: unknown,
+  requestFields: Record<string, unknown>,
+  startedAt: number,
+): void {
+  if (error instanceof LibrusNetworkTimeoutError) {
+    logger.log("warn", "synergia.timeout", {
+      ...requestFields,
+      durationMs: Date.now() - startedAt,
+      timeoutMs: error.details?.timeoutMs,
+    });
   }
 
-  return {
-    data: await response.arrayBuffer(),
-    contentDisposition: response.headers.get("content-disposition"),
-    contentType: response.headers.get("content-type"),
-  };
+  logger.log("error", "synergia.request.failure", {
+    ...requestFields,
+    durationMs: Date.now() - startedAt,
+    ...getErrorLogFields(error),
+  });
 }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -24,26 +24,35 @@ import {
 import {
   LibrusSdkError,
   LibrusNetworkTimeoutError,
+  SynergiaApiClient,
   type ChildAccount,
   type ChildAccountSummary,
+  type Logger,
 } from "../src/sdk/index.js";
 
 const packageJson = JSON.parse(
   readFileSync(new URL("../package.json", import.meta.url), "utf8"),
 ) as { bin: Record<string, string>; version: string };
 const originalLibrusChild = process.env.LIBRUS_CHILD;
+const originalLibrusLogLevel = process.env.LIBRUS_LOG_LEVEL;
 
 beforeEach(() => {
   delete process.env.LIBRUS_CHILD;
+  delete process.env.LIBRUS_LOG_LEVEL;
 });
 
 afterEach(() => {
   if (originalLibrusChild === undefined) {
     delete process.env.LIBRUS_CHILD;
-    return;
+  } else {
+    process.env.LIBRUS_CHILD = originalLibrusChild;
   }
 
-  process.env.LIBRUS_CHILD = originalLibrusChild;
+  if (originalLibrusLogLevel === undefined) {
+    delete process.env.LIBRUS_LOG_LEVEL;
+  } else {
+    process.env.LIBRUS_LOG_LEVEL = originalLibrusLogLevel;
+  }
 });
 
 function createChild(overrides: Partial<ChildAccount> = {}): ChildAccount {
@@ -91,6 +100,36 @@ function createGatewayApi20SessionStub() {
         Url: "https://synergia.librus.pl/gateway/api/2.0/Grades",
       }),
     }),
+  };
+}
+
+function createLoggingGatewayApi20SessionStub(logger?: Logger) {
+  return {
+    getApiBackend: () => "gateway_api_20",
+    getAuthMode: () => "synergia",
+    forChild: async () => {
+      const options = {
+        authMode: "cookie",
+        fetch: vi.fn<typeof fetch>().mockResolvedValue(
+          new Response(
+            JSON.stringify({
+              Grades: [],
+              Resources: {},
+              Url: "https://synergia.librus.pl/gateway/api/2.0/Grades",
+            }),
+            {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            },
+          ),
+        ),
+      } as const;
+
+      return new SynergiaApiClient(
+        "",
+        logger === undefined ? options : { ...options, logger },
+      );
+    },
   };
 }
 
@@ -170,6 +209,74 @@ describe("runCli", () => {
     expect(exitCode).toBe(0);
     expect(stderr).toBe("");
     expect(output.data.Grades).toEqual([]);
+  });
+
+  it("writes verbose SDK logs to stderr without changing JSON stdout", async () => {
+    let stdout = "";
+    let stderr = "";
+    const exitCode = await runCli(
+      withJsonFormat(["node", "librus", "--verbose", "grades", "list"]),
+      {
+        stdout: { write: (chunk) => (stdout += chunk) },
+        stderr: { write: (chunk) => (stderr += chunk) },
+        createSession: (logger) =>
+          createLoggingGatewayApi20SessionStub(logger) as never,
+        outputWidth: 80,
+      },
+    );
+    const output = parseJson<{ data: { Grades: unknown[] } }>(stdout);
+
+    expect(exitCode).toBe(0);
+    expect(output.data.Grades).toEqual([]);
+    expect(stderr).toContain("DEBUG synergia.request.start");
+    expect(stderr).toContain("INFO synergia.request.success");
+    expect(stderr).not.toContain("super-secret");
+    expect(stderr).not.toContain("Bearer");
+  });
+
+  it("enables SDK logs from LIBRUS_LOG_LEVEL", async () => {
+    process.env.LIBRUS_LOG_LEVEL = "info";
+    let stdout = "";
+    let stderr = "";
+    const exitCode = await runCli(
+      withJsonFormat(["node", "librus", "grades", "list"]),
+      {
+        stdout: { write: (chunk) => (stdout += chunk) },
+        stderr: { write: (chunk) => (stderr += chunk) },
+        createSession: (logger) =>
+          createLoggingGatewayApi20SessionStub(logger) as never,
+        outputWidth: 80,
+      },
+    );
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('"Grades": []');
+    expect(stderr).not.toContain("DEBUG synergia.request.start");
+    expect(stderr).toContain("INFO synergia.request.success");
+    expect(stderr).not.toContain("super-secret");
+  });
+
+  it("returns a structured error for invalid LIBRUS_LOG_LEVEL", async () => {
+    process.env.LIBRUS_LOG_LEVEL = "trace";
+    let stdout = "";
+    let stderr = "";
+    const exitCode = await runCli(
+      withJsonFormat(["node", "librus", "grades", "list"]),
+      {
+        stdout: { write: (chunk) => (stdout += chunk) },
+        stderr: { write: (chunk) => (stderr += chunk) },
+        createSession: () => createGatewayApi20SessionStub() as never,
+        outputWidth: 80,
+      },
+    );
+    const output = parseJson<{ error: { code: string; message: string } }>(
+      stderr,
+    );
+
+    expect(exitCode).toBe(1);
+    expect(stdout).toBe("");
+    expect(output.error.code).toBe("CONFIGURATION_ERROR");
+    expect(output.error.message).toContain("LIBRUS_LOG_LEVEL");
   });
 
   it("returns a structured unsupported error when gateway_api_20 receives --child", async () => {

--- a/test/logger.test.ts
+++ b/test/logger.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { Logger, LogLevel } from "../src/sdk/index.js";
+import { LibrusSession, PortalClient } from "../src/sdk/index.js";
+import { SynergiaApiClient } from "../src/sdk/synergia/SynergiaApiClient.js";
+
+interface LogRecord {
+  level: LogLevel;
+  event: string;
+  fields?: Record<string, unknown>;
+}
+
+function createLogger(): { logger: Logger; records: LogRecord[] } {
+  const records: LogRecord[] = [];
+
+  return {
+    logger: {
+      log: (level, event, fields) => records.push({ level, event, fields }),
+    },
+    records,
+  };
+}
+
+function createAbortAwareHangingFetch() {
+  return vi.fn<typeof fetch>((_input, init) => {
+    return new Promise<Response>((_resolve, reject) => {
+      init?.signal?.addEventListener(
+        "abort",
+        () => {
+          reject(new DOMException("This operation was aborted", "AbortError"));
+        },
+        { once: true },
+      );
+    });
+  });
+}
+
+function createGradesResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      Grades: [],
+      Resources: {},
+      Url: "https://api.librus.pl/3.0/Grades",
+    }),
+    {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    },
+  );
+}
+
+function expectNoSecrets(records: LogRecord[]): void {
+  const serialized = JSON.stringify(records);
+
+  expect(serialized).not.toContain("super-secret");
+  expect(serialized).not.toContain("token-secret");
+  expect(serialized).not.toContain("Bearer");
+  expect(serialized).not.toContain("set-cookie");
+  expect(serialized).not.toContain("password=");
+}
+
+describe("SDK logging hooks", () => {
+  it("emits secret-safe Synergia request lifecycle events", async () => {
+    const { logger, records } = createLogger();
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(createGradesResponse());
+    const client = new SynergiaApiClient("token-secret", {
+      fetch: fetchMock,
+      logger,
+    });
+
+    await client.getGrades();
+
+    expect(records.map((record) => record.event)).toEqual([
+      "synergia.request.start",
+      "synergia.request.success",
+    ]);
+    expect(records[0]?.fields).toMatchObject({
+      authMode: "bearer",
+      endpoint: "https://api.librus.pl/3.0/Grades",
+      method: "GET",
+      path: "/Grades",
+    });
+    expect(records[1]?.fields).toMatchObject({
+      status: 200,
+    });
+    expectNoSecrets(records);
+  });
+
+  it("emits secret-safe Synergia failure and timeout events", async () => {
+    vi.useFakeTimers();
+
+    try {
+      const { logger, records } = createLogger();
+      const fetchMock = createAbortAwareHangingFetch();
+      const client = new SynergiaApiClient("token-secret", {
+        fetch: fetchMock,
+        logger,
+        requestTimeoutMs: 5,
+      });
+      const requestPromise = client
+        .getGrades()
+        .catch((error: unknown) => error);
+
+      await vi.advanceTimersByTimeAsync(5);
+      await expect(requestPromise).resolves.toMatchObject({
+        code: "NETWORK_TIMEOUT",
+      });
+
+      expect(records.map((record) => record.event)).toEqual([
+        "synergia.request.start",
+        "synergia.timeout",
+        "synergia.request.failure",
+      ]);
+      expect(records[1]?.fields).toMatchObject({
+        timeoutMs: 5,
+      });
+      expect(records[2]?.fields).toMatchObject({
+        errorCode: "NETWORK_TIMEOUT",
+      });
+      expectNoSecrets(records);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("emits secret-safe Portal login events", async () => {
+    const { logger, records } = createLogger();
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(
+          '<input type="hidden" name="_token" value="csrf-token-123">',
+          {
+            status: 200,
+          },
+        ),
+      )
+      .mockResolvedValueOnce(new Response("", { status: 200 }))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            identifier: 1,
+            email: "parent@example.com",
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      );
+    const client = new PortalClient({ fetch: fetchMock, logger });
+
+    await client.login({
+      email: "parent@example.com",
+      password: "super-secret",
+    });
+
+    expect(records.map((record) => record.event)).toEqual([
+      "portal.login.start",
+      "portal.login.success",
+    ]);
+    expectNoSecrets(records);
+  });
+
+  it("uses the noop logger by default", async () => {
+    const consoleSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(createGradesResponse());
+    const client = new SynergiaApiClient("token-secret", { fetch: fetchMock });
+
+    await client.getGrades();
+
+    expect(consoleSpy).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it("propagates the session logger to internally created clients", async () => {
+    const { logger, records } = createLogger();
+    const child = {
+      id: 1,
+      accountIdentifier: "child-1",
+      group: "parent",
+      login: "child-login",
+      studentName: "Child Name",
+      accessToken: "token-secret",
+      state: "active",
+    };
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(createGradesResponse());
+    const session = new LibrusSession({
+      apiBackend: "api_v3",
+      credentials: {
+        email: "parent@example.com",
+        password: "super-secret",
+      },
+      logger,
+      synergiaClientOptions: {
+        fetch: fetchMock,
+      },
+    });
+    const client = await session.forChild(child);
+
+    await client.getGrades();
+
+    expect(records.map((record) => record.event)).toEqual([
+      "synergia.request.start",
+      "synergia.request.success",
+    ]);
+    expectNoSecrets(records);
+  });
+
+  it("preserves explicit nested Synergia logger overrides", async () => {
+    const sessionLogger = createLogger();
+    const nestedLogger = createLogger();
+    const child = {
+      id: 1,
+      accountIdentifier: "child-1",
+      group: "parent",
+      login: "child-login",
+      studentName: "Child Name",
+      accessToken: "token-secret",
+      state: "active",
+    };
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(createGradesResponse());
+    const session = new LibrusSession({
+      apiBackend: "api_v3",
+      credentials: {
+        email: "parent@example.com",
+        password: "super-secret",
+      },
+      logger: sessionLogger.logger,
+      synergiaClientOptions: {
+        fetch: fetchMock,
+        logger: nestedLogger.logger,
+      },
+    });
+    const client = await session.forChild(child);
+
+    await client.getGrades();
+
+    expect(sessionLogger.records).toEqual([]);
+    expect(nestedLogger.records.map((record) => record.event)).toEqual([
+      "synergia.request.start",
+      "synergia.request.success",
+    ]);
+    expectNoSecrets(nestedLogger.records);
+  });
+});


### PR DESCRIPTION
## Summary

- Add a tiny SDK logger surface (Logger, LogLevel, noopLogger) and export it from the package root.
- Wire secret-safe logging through Portal login, Synergia request lifecycle, timeout diagnostics, and session-created clients.
- Add CLI --verbose and LIBRUS_LOG_LEVEL stderr diagnostics while keeping normal command output on stdout.
- Document custom logger usage and add focused coverage for logger events, redaction, session propagation, and CLI behavior.

## Impact

SDK users can attach their own logger or APM adapter without forking, and CLI users can enable human-readable diagnostics for auth/request troubleshooting. Logged fields intentionally avoid credentials, bearer tokens, cookies, request bodies, and response bodies.

## Validation

- npm run validate

Fixes LIB-13.