### PR TITLE
Require Node.js >=22.12.0 for commander 15 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 22
+          node-version: 22.12
           cache: npm
 
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "./openapi/wiadomosci_librus_pl_api_openapi.json": "./openapi/wiadomosci_librus_pl_api_openapi.json"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=22.12.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",


### PR DESCRIPTION
## Summary

- Bumps `engines.node` from `>=22` to `>=22.12.0` in `package.json`
- Pins CI `node-version` to `22.12` in both jobs in `.github/workflows/ci.yml`

Commander 15 (PR #107) is ESM-only and requires Node ≥ 22.12.0 for `require(esm)` support. Without this change, any Node 22.x install below 22.12.0 could break.

## Test plan

- [ ] CI passes on Node 22.12
- [ ] After this merges, PR #107 (`commander` 14 → 15 bump) is safe to merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)