### PR TITLE
[codex] run Dependabot on Wednesdays and Saturdays

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,8 @@ updates:
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: weekly
-      day: saturday
-      time: "09:00"
+      interval: cron
+      cronjob: "0 9 * * 3,6"
       timezone: Europe/Warsaw
     open-pull-requests-limit: 5
     labels:
@@ -18,9 +17,8 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
-      day: saturday
-      time: "09:30"
+      interval: cron
+      cronjob: "30 9 * * 3,6"
       timezone: Europe/Warsaw
     open-pull-requests-limit: 5
     labels:


### PR DESCRIPTION
## Summary
- run npm Dependabot updates on Wednesdays and Saturdays at 09:00 Europe/Warsaw
- run GitHub Actions Dependabot updates on Wednesdays and Saturdays at 09:30 Europe/Warsaw
- use Dependabot's supported cron schedule format for twice-weekly runs

## Why
A weekly Saturday-only dependency update cadence is too infrequent. Running twice weekly shortens the time between upstream releases and dependency review without creating daily update noise.

## Impact
No SDK or CLI runtime behavior changes.

## Validation
- parsed `.github/dependabot.yml` with the local YAML parser
- ran `npx prettier --check .github/dependabot.yml`
- ran `git diff --check master...HEAD`
