### PR TITLE
feat(synergia): retry/backoff for transient failures (LIB-10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,12 +301,31 @@ here rather than promising every helper type as a named top-level export.
 
 `SynergiaApiClient` constructor options (`SynergiaApiClientOptions`):
 
-| Property           | Required | Meaning                                                         |
-| ------------------ | -------- | --------------------------------------------------------------- |
-| `fetch`            | No       | Custom fetch implementation for child-scoped API requests.      |
-| `apiBaseUrl`       | No       | Synergia API base URL. Defaults to `https://api.librus.pl/3.0`. |
-| `authMode`         | No       | `bearer` by default, or `cookie` for Gateway-created sessions.  |
-| `requestTimeoutMs` | No       | Positive integer timeout in milliseconds. Defaults to `30000`.  |
+| Property           | Required | Meaning                                                                |
+| ------------------ | -------- | ---------------------------------------------------------------------- |
+| `fetch`            | No       | Custom fetch implementation for child-scoped API requests.             |
+| `apiBaseUrl`       | No       | Synergia API base URL. Defaults to `https://api.librus.pl/3.0`.        |
+| `authMode`         | No       | `bearer` by default, or `cookie` for Gateway-created sessions.         |
+| `requestTimeoutMs` | No       | Positive integer timeout in milliseconds. Defaults to `30000`.         |
+| `retry`            | No       | Retry policy for transient failures, or `false` to disable. See below. |
+
+#### Retry / backoff
+
+Transient Synergia failures (`408, 425, 429, 500, 502, 503, 504`) are retried
+automatically with exponential backoff and full jitter. Only idempotent methods
+(`GET`, `HEAD`) are retried by default, `Retry-After` is honored on `429`, and an
+in-flight `AbortSignal` cancels pending retries immediately. Per-attempt timeouts
+and deterministic errors (validation failures) are never retried. Pass
+`retry: false` to disable retries entirely.
+
+| `retry` field       | Default                               | Meaning                                 |
+| ------------------- | ------------------------------------- | --------------------------------------- |
+| `maxAttempts`       | `3`                                   | Total attempts, including the first.    |
+| `baseDelayMs`       | `250`                                 | Base delay for exponential backoff.     |
+| `maxDelayMs`        | `5000`                                | Upper bound for a single backoff delay. |
+| `retriableStatuses` | `[408, 425, 429, 500, 502, 503, 504]` | HTTP statuses that trigger a retry.     |
+| `retriableMethods`  | `["GET", "HEAD"]`                     | HTTP methods eligible for retry.        |
+| `jitter`            | `true`                                | Apply full jitter to backoff delays.    |
 
 OpenAPI generator options (`GenerateOpenApiDocumentOptions`):
 

--- a/src/sdk/synergia/SynergiaApiClient.ts
+++ b/src/sdk/synergia/SynergiaApiClient.ts
@@ -207,6 +207,8 @@ import {
   resolveRequestTimeoutMs,
   wrapFetchWithTimeout,
 } from "../requestTimeout.js";
+import { resolveRetryConfig, wrapFetchWithRetry } from "./retry.js";
+import type { RetryOption } from "./retry.js";
 import { noopLogger, type Logger } from "../logger.js";
 
 export interface SynergiaApiClientOptions {
@@ -215,6 +217,7 @@ export interface SynergiaApiClientOptions {
   authMode?: SynergiaAuthMode;
   messageBackend?: MessageReadBackend;
   requestTimeoutMs?: number;
+  retry?: RetryOption;
   logger?: Logger;
 }
 
@@ -238,10 +241,18 @@ export class SynergiaApiClient {
     this.authMode = options.authMode ?? "bearer";
     this.logger = options.logger ?? noopLogger;
     this.requestTimeoutMs = resolveRequestTimeoutMs(options.requestTimeoutMs);
-    this.fetchImpl = wrapFetchWithTimeout(
+    const timeoutFetch = wrapFetchWithTimeout(
       options.fetch ?? fetch,
       this.requestTimeoutMs,
     );
+    this.fetchImpl =
+      options.retry === false
+        ? timeoutFetch
+        : wrapFetchWithRetry(
+            timeoutFetch,
+            resolveRetryConfig(options.retry),
+            this.logger,
+          );
     this.apiBaseUrl = options.apiBaseUrl ?? "https://api.librus.pl/3.0";
     this.messageBackend = options.messageBackend;
   }

--- a/src/sdk/synergia/retry.ts
+++ b/src/sdk/synergia/retry.ts
@@ -1,0 +1,406 @@
+import type { FetchLike } from "../models/common.js";
+import {
+  LibrusConfigurationError,
+  LibrusNetworkTimeoutError,
+} from "../models/errors.js";
+import { noopLogger, type Logger } from "../logger.js";
+
+/**
+ * Public retry configuration accepted by `SynergiaApiClientOptions.retry`.
+ *
+ * Pass `false` to disable retries entirely (a single attempt is made).
+ */
+export type RetryOption = RetryOptions | false;
+
+export interface RetryOptions {
+  /** Total attempts including the first. Default 3. */
+  maxAttempts?: number;
+  /** Base delay for exponential backoff, in ms. Default 250. */
+  baseDelayMs?: number;
+  /** Upper bound for a single backoff delay, in ms. Default 5000. */
+  maxDelayMs?: number;
+  /** HTTP statuses that trigger a retry. Default [408,425,429,500,502,503,504]. */
+  retriableStatuses?: number[];
+  /** HTTP methods eligible for retry. Default ["GET","HEAD"]. */
+  retriableMethods?: string[];
+  /** Apply full jitter to backoff delays. Default true. */
+  jitter?: boolean;
+}
+
+/** Fully-resolved retry configuration with all defaults applied. */
+export interface ResolvedRetryConfig {
+  maxAttempts: number;
+  baseDelayMs: number;
+  maxDelayMs: number;
+  retriableStatuses: ReadonlySet<number>;
+  retriableMethods: ReadonlySet<string>;
+  jitter: boolean;
+}
+
+export const DEFAULT_RETRY_MAX_ATTEMPTS = 3;
+export const DEFAULT_RETRY_BASE_DELAY_MS = 250;
+export const DEFAULT_RETRY_MAX_DELAY_MS = 5_000;
+export const DEFAULT_RETRIABLE_STATUSES: readonly number[] = [
+  408, 425, 429, 500, 502, 503, 504,
+];
+export const DEFAULT_RETRIABLE_METHODS: readonly string[] = ["GET", "HEAD"];
+
+/** Injectable source of randomness for jitter (overridable in tests). */
+export type RandomFn = () => number;
+
+function validatePositiveInteger(
+  value: number,
+  source: string,
+  { allowZero = false }: { allowZero?: boolean } = {},
+): number {
+  const lowerBoundOk = allowZero ? value >= 0 : value > 0;
+
+  if (!Number.isSafeInteger(value) || !lowerBoundOk) {
+    throw new LibrusConfigurationError(
+      `Invalid ${source}. Expected a ${
+        allowZero ? "non-negative" : "positive"
+      } integer.`,
+    );
+  }
+
+  return value;
+}
+
+/**
+ * Validate and normalize a {@link RetryOption} into a {@link ResolvedRetryConfig}.
+ *
+ * Throws {@link LibrusConfigurationError} for malformed values. Mirrors the
+ * `resolveRequestTimeoutMs` / `validateRequestTimeoutMs` pattern in
+ * `requestTimeout.ts`.
+ */
+export function resolveRetryConfig(
+  option: RetryOption | undefined,
+): ResolvedRetryConfig {
+  const options: RetryOptions =
+    option === false || option === undefined ? {} : option;
+
+  const maxAttempts = validatePositiveInteger(
+    options.maxAttempts ?? DEFAULT_RETRY_MAX_ATTEMPTS,
+    "retry.maxAttempts",
+  );
+  const baseDelayMs = validatePositiveInteger(
+    options.baseDelayMs ?? DEFAULT_RETRY_BASE_DELAY_MS,
+    "retry.baseDelayMs",
+    { allowZero: true },
+  );
+  const maxDelayMs = validatePositiveInteger(
+    options.maxDelayMs ?? DEFAULT_RETRY_MAX_DELAY_MS,
+    "retry.maxDelayMs",
+    { allowZero: true },
+  );
+
+  if (maxDelayMs < baseDelayMs) {
+    throw new LibrusConfigurationError(
+      "Invalid retry config. retry.maxDelayMs must be >= retry.baseDelayMs.",
+    );
+  }
+
+  const retriableStatuses =
+    options.retriableStatuses ?? DEFAULT_RETRIABLE_STATUSES;
+
+  for (const status of retriableStatuses) {
+    validatePositiveInteger(status, "retry.retriableStatuses entry");
+  }
+
+  const retriableMethods =
+    options.retriableMethods ?? DEFAULT_RETRIABLE_METHODS;
+
+  return {
+    maxAttempts,
+    baseDelayMs,
+    maxDelayMs,
+    retriableStatuses: new Set(retriableStatuses),
+    retriableMethods: new Set(
+      retriableMethods.map((method) => method.toUpperCase()),
+    ),
+    jitter: options.jitter ?? true,
+  };
+}
+
+/** Compute the (capped, optionally jittered) backoff delay for an attempt. */
+export function computeBackoffDelay(
+  attempt: number,
+  config: Pick<ResolvedRetryConfig, "baseDelayMs" | "maxDelayMs" | "jitter">,
+  random: RandomFn = Math.random,
+): number {
+  const exponential = config.baseDelayMs * 2 ** (attempt - 1);
+  const capped = Math.min(config.maxDelayMs, exponential);
+
+  if (!config.jitter) {
+    return capped;
+  }
+
+  // Full jitter: a uniformly random delay in [0, capped], so the realized
+  // delay never exceeds the capped value (relied upon by the property test).
+  return random() * capped;
+}
+
+/**
+ * Parse an HTTP `Retry-After` header value into milliseconds.
+ *
+ * Supports both the delta-seconds form (`"2"`) and the HTTP-date form
+ * (`"Wed, 21 Oct 2026 07:28:00 GMT"`). Returns `undefined` when the value is
+ * absent or unparseable.
+ */
+export function parseRetryAfter(
+  headerValue: string | null | undefined,
+  now: number = Date.now(),
+): number | undefined {
+  if (headerValue === null || headerValue === undefined) {
+    return undefined;
+  }
+
+  const trimmed = headerValue.trim();
+
+  if (trimmed === "") {
+    return undefined;
+  }
+
+  if (/^\d+$/u.test(trimmed)) {
+    return Number.parseInt(trimmed, 10) * 1_000;
+  }
+
+  const dateMs = Date.parse(trimmed);
+
+  if (Number.isNaN(dateMs)) {
+    return undefined;
+  }
+
+  return Math.max(0, dateMs - now);
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
+}
+
+function createAbortError(signal: AbortSignal): Error {
+  const reason = signal.reason as unknown;
+
+  if (reason instanceof Error) {
+    return reason;
+  }
+
+  const error = new Error(
+    typeof reason === "string" ? reason : "The operation was aborted.",
+  );
+  error.name = "AbortError";
+
+  return error;
+}
+
+/**
+ * Resolve after `ms`, or reject with an `AbortError` if `signal` aborts during
+ * the wait. Always clears its timer and listener (no dangling handles).
+ */
+export function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(createAbortError(signal));
+
+      return;
+    }
+
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(createAbortError(signal as AbortSignal));
+    };
+
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+/** Describes how a single attempt should be retried (or not). */
+export interface RetryDecision {
+  retry: boolean;
+  /** Explicit delay override (e.g. honoring `Retry-After`), in ms. */
+  delayMs?: number;
+  /** Short machine-readable reason, surfaced in retry log events. */
+  reason?: string;
+}
+
+export interface WithRetryConfig<T> extends Pick<
+  ResolvedRetryConfig,
+  "maxAttempts" | "baseDelayMs" | "maxDelayMs" | "jitter"
+> {
+  /** Inspect a resolved value to decide whether to retry. */
+  shouldRetry: (value: T) => RetryDecision;
+  /** Inspect a thrown error to decide whether to retry. */
+  shouldRetryError: (error: unknown) => RetryDecision;
+  signal?: AbortSignal | undefined;
+  random?: RandomFn;
+  /** Invoked before each backoff sleep, for structured logging. */
+  onRetry?: (info: {
+    attempt: number;
+    delayMs: number;
+    reason?: string;
+  }) => void;
+}
+
+/**
+ * Generic retry primitive with exponential backoff + jitter.
+ *
+ * Retries when either the resolved value (`shouldRetry`) or a thrown error
+ * (`shouldRetryError`) is flagged. Honors an `AbortSignal`: an abort before or
+ * during a backoff wait rejects immediately with no further attempts.
+ *
+ * Shaped for reuse beyond HTTP — e.g. LIB-9's 401 auth refresh, where the
+ * retriable condition is a thrown error rather than a resolved response.
+ */
+export async function withRetry<T>(
+  fn: (attempt: number) => Promise<T>,
+  config: WithRetryConfig<T>,
+): Promise<T> {
+  const random = config.random ?? Math.random;
+  let attempt = 0;
+
+  for (;;) {
+    attempt += 1;
+
+    if (config.signal?.aborted) {
+      throw createAbortError(config.signal);
+    }
+
+    let decision: RetryDecision;
+    let outcome:
+      | { kind: "value"; value: T }
+      | { kind: "error"; error: unknown };
+
+    try {
+      const value = await fn(attempt);
+      decision = config.shouldRetry(value);
+      outcome = { kind: "value", value };
+    } catch (error) {
+      // A caller-driven abort is terminal and never retried.
+      if (isAbortError(error)) {
+        throw error;
+      }
+
+      decision = config.shouldRetryError(error);
+      outcome = { kind: "error", error };
+    }
+
+    const isLastAttempt = attempt >= config.maxAttempts;
+
+    if (!decision.retry || isLastAttempt) {
+      if (outcome.kind === "value") {
+        return outcome.value;
+      }
+
+      throw outcome.error;
+    }
+
+    const delayMs =
+      decision.delayMs ?? computeBackoffDelay(attempt, config, random);
+
+    config.onRetry?.({
+      attempt,
+      delayMs,
+      ...(decision.reason !== undefined ? { reason: decision.reason } : {}),
+    });
+
+    await sleep(delayMs, config.signal);
+  }
+}
+
+function getRequestMethod(init: RequestInit | undefined): string {
+  return (init?.method ?? "GET").toUpperCase();
+}
+
+function getRequestUrl(input: RequestInfo | URL): string {
+  if (typeof input === "string") {
+    return input;
+  }
+
+  if (input instanceof URL) {
+    return input.toString();
+  }
+
+  return input.url;
+}
+
+/**
+ * Wrap a fetch implementation with retry/backoff for transient HTTP failures.
+ *
+ * Composes with `wrapFetchWithTimeout`: place retry on the outside so each
+ * attempt receives a fresh per-attempt timeout. Only retries methods in
+ * `config.retriableMethods` (idempotent by default) and statuses in
+ * `config.retriableStatuses`; honors `Retry-After` for 429 responses; respects
+ * the caller's `AbortSignal` during backoff.
+ */
+export function wrapFetchWithRetry(
+  baseFetch: FetchLike,
+  config: ResolvedRetryConfig,
+  logger: Logger = noopLogger,
+): FetchLike {
+  return async (input, init) => {
+    const method = getRequestMethod(init);
+    const endpoint = getRequestUrl(input);
+    const methodIsRetriable = config.retriableMethods.has(method);
+    const signal = init?.signal ?? undefined;
+
+    const decideForResponse = (response: Response): RetryDecision => {
+      if (
+        !methodIsRetriable ||
+        !config.retriableStatuses.has(response.status)
+      ) {
+        return { retry: false };
+      }
+
+      const retryAfterMs =
+        response.status === 429
+          ? parseRetryAfter(response.headers.get("retry-after"))
+          : undefined;
+
+      return {
+        retry: true,
+        ...(retryAfterMs !== undefined ? { delayMs: retryAfterMs } : {}),
+        reason: `status_${response.status}`,
+      };
+    };
+
+    return withRetry<Response>(() => baseFetch(input, init), {
+      maxAttempts: config.maxAttempts,
+      baseDelayMs: config.baseDelayMs,
+      maxDelayMs: config.maxDelayMs,
+      jitter: config.jitter,
+      signal,
+      shouldRetry: (response) => {
+        const decision = decideForResponse(response);
+
+        // Release the discarded response so the socket is not held open.
+        if (decision.retry) {
+          void response.body?.cancel();
+        }
+
+        return decision;
+      },
+      shouldRetryError: (error) =>
+        // Genuine network rejections (e.g. ECONNRESET) are transient and
+        // retriable. Per-attempt timeouts are terminal: retrying them only
+        // multiplies the caller's worst-case wait, so they pass straight
+        // through (matching the standalone timeout contract).
+        methodIsRetriable && !(error instanceof LibrusNetworkTimeoutError)
+          ? { retry: true, reason: "network_error" }
+          : { retry: false },
+      onRetry: ({ attempt, delayMs, reason }) => {
+        logger.log("warn", "synergia.retry", {
+          attempt,
+          delayMs,
+          endpoint,
+          method,
+          reason,
+        });
+      },
+    });
+  };
+}

--- a/test/retry.test.ts
+++ b/test/retry.test.ts
@@ -1,0 +1,477 @@
+import fc from "fast-check";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { LibrusConfigurationError } from "../src/sdk/models/errors.js";
+import type { Logger } from "../src/sdk/logger.js";
+import { SynergiaApiClient } from "../src/sdk/synergia/SynergiaApiClient.js";
+import {
+  computeBackoffDelay,
+  parseRetryAfter,
+  resolveRetryConfig,
+  sleep,
+  withRetry,
+  wrapFetchWithRetry,
+} from "../src/sdk/synergia/retry.js";
+
+const FAST_CHECK_SETTINGS = {
+  numRuns: 200,
+  seed: 20260404,
+} as const;
+
+const ENDPOINT = "https://api.librus.pl/3.0/Me";
+
+function jsonResponse(status: number, body: unknown = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("retry config resolution", () => {
+  it("applies documented defaults", () => {
+    const config = resolveRetryConfig(undefined);
+
+    expect(config.maxAttempts).toBe(3);
+    expect(config.baseDelayMs).toBe(250);
+    expect(config.maxDelayMs).toBe(5_000);
+    expect(config.jitter).toBe(true);
+    expect([...config.retriableStatuses].sort((a, b) => a - b)).toEqual([
+      408, 425, 429, 500, 502, 503, 504,
+    ]);
+    expect([...config.retriableMethods]).toEqual(["GET", "HEAD"]);
+  });
+
+  it("treats `false` like defaults when resolved (gating happens upstream)", () => {
+    expect(resolveRetryConfig(false).maxAttempts).toBe(3);
+  });
+
+  it("normalizes retriable methods to upper case", () => {
+    const config = resolveRetryConfig({ retriableMethods: ["get", "post"] });
+
+    expect(config.retriableMethods.has("GET")).toBe(true);
+    expect(config.retriableMethods.has("POST")).toBe(true);
+  });
+
+  it.each([
+    { label: "maxAttempts", option: { maxAttempts: 0 } },
+    { label: "maxAttempts non-integer", option: { maxAttempts: 1.5 } },
+    { label: "baseDelayMs negative", option: { baseDelayMs: -1 } },
+    { label: "status non-integer", option: { retriableStatuses: [1.2] } },
+    {
+      label: "maxDelay < baseDelay",
+      option: { baseDelayMs: 1000, maxDelayMs: 100 },
+    },
+  ])("rejects invalid config: $label", ({ option }) => {
+    expect(() => resolveRetryConfig(option)).toThrow(LibrusConfigurationError);
+  });
+});
+
+describe("computeBackoffDelay", () => {
+  it("grows exponentially and caps at maxDelayMs without jitter", () => {
+    const config = { baseDelayMs: 100, maxDelayMs: 500, jitter: false };
+
+    expect(computeBackoffDelay(1, config)).toBe(100);
+    expect(computeBackoffDelay(2, config)).toBe(200);
+    expect(computeBackoffDelay(3, config)).toBe(400);
+    expect(computeBackoffDelay(4, config)).toBe(500); // capped (would be 800)
+  });
+
+  it("never exceeds the capped delay with full jitter", () => {
+    const config = { baseDelayMs: 100, maxDelayMs: 500, jitter: true };
+
+    for (const random of [0, 0.5, 0.999_999]) {
+      expect(computeBackoffDelay(3, config, () => random)).toBeLessThanOrEqual(
+        400,
+      );
+    }
+  });
+});
+
+describe("parseRetryAfter", () => {
+  it("parses delta-seconds into milliseconds", () => {
+    expect(parseRetryAfter("2")).toBe(2_000);
+    expect(parseRetryAfter("0")).toBe(0);
+  });
+
+  it("parses HTTP-date relative to now", () => {
+    const now = Date.parse("Wed, 21 Oct 2026 07:28:00 GMT");
+    const future = "Wed, 21 Oct 2026 07:28:05 GMT";
+
+    expect(parseRetryAfter(future, now)).toBe(5_000);
+  });
+
+  it("clamps past HTTP-dates to zero", () => {
+    const now = Date.parse("Wed, 21 Oct 2026 07:28:10 GMT");
+    const past = "Wed, 21 Oct 2026 07:28:00 GMT";
+
+    expect(parseRetryAfter(past, now)).toBe(0);
+  });
+
+  it("returns undefined for missing or unparseable values", () => {
+    expect(parseRetryAfter(null)).toBeUndefined();
+    expect(parseRetryAfter(undefined)).toBeUndefined();
+    expect(parseRetryAfter("   ")).toBeUndefined();
+    expect(parseRetryAfter("soon")).toBeUndefined();
+  });
+});
+
+describe("sleep", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("resolves after the delay", async () => {
+    let resolved = false;
+    const promise = sleep(100).then(() => {
+      resolved = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(99);
+    expect(resolved).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    await promise;
+    expect(resolved).toBe(true);
+  });
+
+  it("rejects immediately when the signal is already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    const error = await sleep(100, controller.signal).catch((e: unknown) => e);
+
+    expect((error as Error).name).toBe("AbortError");
+  });
+
+  it("rejects when aborted mid-wait and clears its timer", async () => {
+    const controller = new AbortController();
+    const promise = sleep(100, controller.signal).catch((e: unknown) => e);
+
+    await vi.advanceTimersByTimeAsync(10);
+    controller.abort();
+
+    const error = await promise;
+    expect((error as Error).name).toBe("AbortError");
+  });
+});
+
+describe("withRetry (generic primitive)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("retries on a thrown error flagged by shouldRetryError (LIB-9 shape)", async () => {
+    const fn = vi
+      .fn<(attempt: number) => Promise<string>>()
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValueOnce("ok");
+
+    const promise = withRetry(fn, {
+      maxAttempts: 3,
+      baseDelayMs: 100,
+      maxDelayMs: 1_000,
+      jitter: false,
+      shouldRetry: () => ({ retry: false }),
+      shouldRetryError: () => ({ retry: true }),
+    });
+
+    await vi.advanceTimersByTimeAsync(100);
+    await expect(promise).resolves.toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("never retries an AbortError even if shouldRetryError says so", async () => {
+    const abortError = new Error("aborted");
+    abortError.name = "AbortError";
+    const fn = vi
+      .fn<(attempt: number) => Promise<string>>()
+      .mockRejectedValue(abortError);
+
+    const error = await withRetry(fn, {
+      maxAttempts: 3,
+      baseDelayMs: 100,
+      maxDelayMs: 1_000,
+      jitter: false,
+      shouldRetry: () => ({ retry: false }),
+      shouldRetryError: () => ({ retry: true }),
+    }).catch((e: unknown) => e);
+
+    expect((error as Error).name).toBe("AbortError");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("wrapFetchWithRetry", () => {
+  const config = resolveRetryConfig({
+    maxAttempts: 3,
+    baseDelayMs: 100,
+    maxDelayMs: 5_000,
+    jitter: false,
+  });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("retries a 503 then succeeds on the 200", async () => {
+    const baseFetch = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(jsonResponse(503))
+      .mockResolvedValueOnce(jsonResponse(200, { ok: true }));
+    const wrapped = wrapFetchWithRetry(baseFetch, config);
+
+    const promise = wrapped(ENDPOINT, { method: "GET" });
+    await vi.advanceTimersByTimeAsync(100);
+
+    const response = await promise;
+    expect(response.status).toBe(200);
+    expect(baseFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("honors Retry-After seconds on a 429", async () => {
+    const baseFetch = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(null, { status: 429, headers: { "retry-after": "2" } }),
+      )
+      .mockResolvedValueOnce(jsonResponse(200));
+    const wrapped = wrapFetchWithRetry(baseFetch, config);
+
+    const promise = wrapped(ENDPOINT, { method: "GET" });
+
+    await vi.advanceTimersByTimeAsync(1_999);
+    expect(baseFetch).toHaveBeenCalledTimes(1); // still waiting out Retry-After
+    await vi.advanceTimersByTimeAsync(1);
+
+    await expect(promise).resolves.toMatchObject({ status: 200 });
+    expect(baseFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("honors Retry-After HTTP-date on a 429", async () => {
+    const base = Date.parse("Wed, 21 Oct 2026 07:28:00 GMT");
+    vi.setSystemTime(base);
+    const baseFetch = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 429,
+          headers: { "retry-after": "Wed, 21 Oct 2026 07:28:03 GMT" },
+        }),
+      )
+      .mockResolvedValueOnce(jsonResponse(200));
+    const wrapped = wrapFetchWithRetry(baseFetch, config);
+
+    const promise = wrapped(ENDPOINT, { method: "GET" });
+
+    await vi.advanceTimersByTimeAsync(2_999);
+    expect(baseFetch).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+
+    await expect(promise).resolves.toMatchObject({ status: 200 });
+    expect(baseFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("aborts during backoff and makes no further attempts", async () => {
+    const controller = new AbortController();
+    const baseFetch = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(jsonResponse(503));
+    const wrapped = wrapFetchWithRetry(baseFetch, config);
+
+    const promise = wrapped(ENDPOINT, {
+      method: "GET",
+      signal: controller.signal,
+    }).catch((e: unknown) => e);
+
+    await vi.advanceTimersByTimeAsync(0); // flush first attempt, enter backoff
+    expect(baseFetch).toHaveBeenCalledTimes(1);
+    controller.abort();
+
+    const error = await promise;
+    expect((error as Error).name).toBe("AbortError");
+    expect(baseFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry non-idempotent methods by default", async () => {
+    const baseFetch = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(jsonResponse(503));
+    const wrapped = wrapFetchWithRetry(baseFetch, config);
+
+    const response = await wrapped(ENDPOINT, { method: "POST" });
+
+    expect(response.status).toBe(503);
+    expect(baseFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries non-idempotent methods when explicitly opted in", async () => {
+    const optInConfig = resolveRetryConfig({
+      maxAttempts: 2,
+      baseDelayMs: 100,
+      maxDelayMs: 5_000,
+      jitter: false,
+      retriableMethods: ["GET", "POST"],
+    });
+    const baseFetch = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(jsonResponse(503))
+      .mockResolvedValueOnce(jsonResponse(200));
+    const wrapped = wrapFetchWithRetry(baseFetch, optInConfig);
+
+    const promise = wrapped(ENDPOINT, { method: "POST" });
+    await vi.advanceTimersByTimeAsync(100);
+
+    await expect(promise).resolves.toMatchObject({ status: 200 });
+    expect(baseFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries transient network rejections", async () => {
+    const baseFetch = vi
+      .fn<typeof fetch>()
+      .mockRejectedValueOnce(new TypeError("network error"))
+      .mockResolvedValueOnce(jsonResponse(200));
+    const wrapped = wrapFetchWithRetry(baseFetch, config);
+
+    const promise = wrapped(ENDPOINT, { method: "GET" });
+    await vi.advanceTimersByTimeAsync(100);
+
+    await expect(promise).resolves.toMatchObject({ status: 200 });
+    expect(baseFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns the last response after exhausting attempts", async () => {
+    const exhaustConfig = resolveRetryConfig({
+      maxAttempts: 2,
+      baseDelayMs: 100,
+      maxDelayMs: 5_000,
+      jitter: false,
+    });
+    const baseFetch = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(jsonResponse(503));
+    const wrapped = wrapFetchWithRetry(baseFetch, exhaustConfig);
+
+    const promise = wrapped(ENDPOINT, { method: "GET" });
+    await vi.advanceTimersByTimeAsync(100);
+
+    await expect(promise).resolves.toMatchObject({ status: 503 });
+    expect(baseFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("emits a structured log event per retry", async () => {
+    const log = vi.fn();
+    const logger: Logger = { log };
+    const baseFetch = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(jsonResponse(503))
+      .mockResolvedValueOnce(jsonResponse(200));
+    const wrapped = wrapFetchWithRetry(baseFetch, config, logger);
+
+    const promise = wrapped(ENDPOINT, { method: "GET" });
+    await vi.advanceTimersByTimeAsync(100);
+    await promise;
+
+    expect(log).toHaveBeenCalledWith(
+      "warn",
+      "synergia.retry",
+      expect.objectContaining({
+        attempt: 1,
+        endpoint: ENDPOINT,
+        method: "GET",
+        reason: "status_503",
+      }),
+    );
+  });
+});
+
+describe("SynergiaApiClient retry wiring", () => {
+  it("makes exactly one attempt when retry is disabled", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(jsonResponse(503));
+    const client = new SynergiaApiClient("token", {
+      fetch: fetchMock,
+      retry: false,
+    });
+
+    await expect(client.getMe()).rejects.toMatchObject({
+      code: "API_REQUEST_FAILED",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry deterministic validation failures", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response("not-json", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const client = new SynergiaApiClient("token", { fetch: fetchMock });
+
+    await expect(client.getMe()).rejects.toBeInstanceOf(Error);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("retry timing properties", () => {
+  it("keeps every backoff delay within its capped bound for random configs", () => {
+    fc.assert(
+      fc.property(
+        fc.record({
+          baseDelayMs: fc.integer({ min: 1, max: 2_000 }),
+          maxDelayMs: fc.integer({ min: 1, max: 30_000 }),
+          attempt: fc.integer({ min: 1, max: 10 }),
+          random: fc.double({ min: 0, max: 1, noNaN: true }),
+        }),
+        ({ baseDelayMs, maxDelayMs, attempt, random }) => {
+          const cap = Math.max(baseDelayMs, maxDelayMs);
+          const config = { baseDelayMs, maxDelayMs: cap, jitter: true };
+          const delay = computeBackoffDelay(attempt, config, () => random);
+          const expectedCap = Math.min(cap, baseDelayMs * 2 ** (attempt - 1));
+
+          expect(delay).toBeGreaterThanOrEqual(0);
+          expect(delay).toBeLessThanOrEqual(expectedCap);
+        },
+      ),
+      FAST_CHECK_SETTINGS,
+    );
+  });
+
+  it("bounds total backoff by the sum of per-attempt caps", () => {
+    fc.assert(
+      fc.property(
+        fc.record({
+          baseDelayMs: fc.integer({ min: 1, max: 1_000 }),
+          maxDelayMs: fc.integer({ min: 1, max: 10_000 }),
+          maxAttempts: fc.integer({ min: 1, max: 6 }),
+        }),
+        ({ baseDelayMs, maxDelayMs, maxAttempts }) => {
+          const cap = Math.max(baseDelayMs, maxDelayMs);
+          const config = { baseDelayMs, maxDelayMs: cap, jitter: true };
+
+          let total = 0;
+          let bound = 0;
+          for (let attempt = 1; attempt < maxAttempts; attempt += 1) {
+            total += computeBackoffDelay(attempt, config, () => 1);
+            bound += Math.min(cap, baseDelayMs * 2 ** (attempt - 1));
+          }
+
+          expect(total).toBeLessThanOrEqual(bound);
+        },
+      ),
+      FAST_CHECK_SETTINGS,
+    );
+  });
+});

--- a/test/synergia-client.test.ts
+++ b/test/synergia-client.test.ts
@@ -60,7 +60,12 @@ describe("SynergiaApiClient", () => {
       ),
     );
 
-    const client = new SynergiaApiClient("token", { fetch: fetchMock });
+    // retry disabled: this test asserts the 503 -> maintenance error mapping,
+    // not retry behavior (which has dedicated coverage in retry.test.ts).
+    const client = new SynergiaApiClient("token", {
+      fetch: fetchMock,
+      retry: false,
+    });
 
     await expect(client.getMe()).rejects.toMatchObject({
       code: "SERVICE_MAINTENANCE",


### PR DESCRIPTION
## Summary

Adds automatic retry with exponential backoff + jitter for transient Synergia failures (LIB-10). Implemented as a composable `wrapFetchWithRetry` fetch wrapper, composed around the existing `wrapFetchWithTimeout` in the `SynergiaApiClient` constructor — so all ~100 child-scoped endpoints gain retry transparently, with no changes to `request.ts` or the endpoint methods. Retry sits **outside** the timeout wrapper, so each attempt gets a fresh per-attempt timeout.

## Behavior

- Retriable statuses: `408, 425, 429, 500, 502, 503, 504` (configurable).
- Idempotent methods only by default (`GET`, `HEAD`); opt-in for others.
- Honors `Retry-After` on `429` (delta-seconds **and** HTTP-date forms).
- Exponential backoff with full jitter; `Retry-After` overrides computed backoff.
- An in-flight `AbortSignal` cancels pending retries immediately (no further attempts).
- **Not** retried: per-attempt timeouts (terminal — avoids multiplying worst-case wait) and deterministic validation errors.
- `retry: false` disables retries entirely.

The generic `withRetry<T>` primitive is shaped for reuse by LIB-9 (401 auth refresh is a special retry case).

## Config (`SynergiaApiClientOptions.retry`)

| Field | Default |
| --- | --- |
| `maxAttempts` | `3` |
| `baseDelayMs` | `250` |
| `maxDelayMs` | `5000` |
| `retriableStatuses` | `[408, 425, 429, 500, 502, 503, 504]` |
| `retriableMethods` | `["GET", "HEAD"]` |
| `jitter` | `true` |

## Tests

`test/retry.test.ts` covers every acceptance criterion (503→200, `Retry-After` seconds + HTTP-date, abort during backoff, idempotency gating + opt-in, `retry: false`, validation-not-retried) plus fast-check property tests for the jitter bound. Full `npm run validate` passes; coverage stays above thresholds.

Closes LIB-10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)