### PR TITLE
fix: redact received payload values from response validation errors

### DIFF
--- a/src/sdk/validation/responseValidation.ts
+++ b/src/sdk/validation/responseValidation.ts
@@ -4,10 +4,25 @@ import { LibrusResponseValidationError } from "../models/errors.js";
 
 const MAX_ISSUES = 3;
 
+/**
+ * Valibot's default issue messages embed the raw received value, e.g.
+ * `Invalid type: Expected number but received "hunter2-SECRET"`. The validated
+ * payload can carry secrets (passwords, tokens, child PII) that the Librus
+ * server echoes back, so the received portion must never reach a thrown error.
+ * Rebuild each message from the `Invalid <label>:` prefix and `issue.expected`
+ * only — both are schema-derived and contain no payload data.
+ */
+function redactReceivedValue(issue: v.BaseIssue<unknown>): string {
+  const label =
+    issue.message.match(/^(Invalid [^:]+):/)?.[1] ?? "Invalid value";
+  return issue.expected ? `${label}: Expected ${issue.expected}` : label;
+}
+
 function summarizeIssues(issues: v.BaseIssue<unknown>[]): string[] {
   return issues.slice(0, MAX_ISSUES).map((issue) => {
     const path = v.getDotPath(issue);
-    return path ? `${path}: ${issue.message}` : issue.message;
+    const message = redactReceivedValue(issue);
+    return path ? `${path}: ${message}` : message;
   });
 }
 

--- a/test/requestTimeout.combineAbortSignals.test.ts
+++ b/test/requestTimeout.combineAbortSignals.test.ts
@@ -1,6 +1,9 @@
+import fc from "fast-check";
 import { describe, expect, it } from "vitest";
 
 import { combineAbortSignals } from "../src/sdk/requestTimeout.js";
+
+const FAST_CHECK_SETTINGS = { numRuns: 200, seed: 20260404 } as const;
 
 describe("combineAbortSignals", () => {
   it("returns timeout signal directly when upstream is undefined", () => {
@@ -91,5 +94,39 @@ describe("combineAbortSignals", () => {
     expect(signal.aborted).toBe(true);
     expect(signal.reason).toBe("first");
     cleanup();
+  });
+});
+
+describe("combineAbortSignals — property", () => {
+  it("aborts exactly once with the first reason for any abort ordering", () => {
+    fc.assert(
+      fc.property(
+        fc.constantFrom("timeout", "upstream"),
+        fc.string(),
+        fc.string(),
+        (firstSource, firstReason, secondReason) => {
+          const tc = new AbortController();
+          const up = new AbortController();
+          const { signal, cleanup } = combineAbortSignals(tc.signal, up.signal);
+
+          let abortCount = 0;
+          signal.addEventListener("abort", () => {
+            abortCount += 1;
+          });
+
+          const [first, second] =
+            firstSource === "timeout" ? [tc, up] : [up, tc];
+          first.abort(firstReason);
+          second.abort(secondReason);
+
+          expect(signal.aborted).toBe(true);
+          expect(abortCount).toBe(1);
+          expect(signal.reason).toBe(firstReason);
+
+          cleanup();
+        },
+      ),
+      FAST_CHECK_SETTINGS,
+    );
   });
 });

--- a/test/responseValidation.truncation.test.ts
+++ b/test/responseValidation.truncation.test.ts
@@ -79,4 +79,22 @@ describe("parseApiResponse — issue truncation", () => {
 
     expect(err.details?.endpoint).toBe(ENDPOINT);
   });
+
+  it("never leaks received payload values into issue summaries", () => {
+    const secretSchema = v.object({
+      password: v.number(),
+      token: v.number(),
+    });
+    const err = throwingParse(secretSchema, {
+      password: "hunter2-SECRET",
+      token: "Bearer-LEAK",
+    });
+    const issues = err.details?.issues ?? [];
+
+    expect(issues.length).toBeGreaterThan(0);
+    for (const issue of issues) {
+      expect(issue).not.toContain("hunter2-SECRET");
+      expect(issue).not.toContain("Bearer-LEAK");
+    }
+  });
 });


### PR DESCRIPTION
## Summary

`summarizeIssues` in `src/sdk/validation/responseValidation.ts` built error strings straight from Valibot's default issue messages, which embed the raw *received* value — e.g. `password: Invalid type: Expected number but received "hunter2-SECRET"`. Since validated payloads can carry secrets (passwords, tokens, child PII) that the Librus server echoes back, `LibrusResponseValidationError.details.issues` could leak them.

Flagged as a "mild secret-adjacent risk" in `.tasks/rearchitect/08-test-coverage.md` and confirmed empirically while working LIB-7. Kept out of LIB-7 because that task was tests-only / no production changes.

## Change

- Added `redactReceivedValue`, which rebuilds each issue summary from the `Invalid <label>:` prefix and `issue.expected` only — both schema-derived — and never includes `issue.received`. Chosen over regex-stripping the `received …` suffix because it can't miss the no-`expected` message form (`Invalid type: Received null`). No schema under `src/sdk/validation/` sets a custom `message:`, so all messages follow Valibot's default `Invalid <label>:` shape.
- Added a guard test parsing `{ password: "hunter2-SECRET", token: "Bearer-LEAK" }` against `v.object({ password: v.number(), token: v.number() })` and asserting no issue summary contains either secret.

## Verification

- `vitest run test/responseValidation.truncation.test.ts` — 7/7 pass (6 existing + 1 new).
- `tsc --noEmit` and `eslint` clean. Existing format/truncation tests unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)