### PR TITLE
Bump github/codeql-action to v4.36.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
           output: trivy-results.sarif
 
       - name: Upload Trivy scan results
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
         if: always()
         with:
           sarif_file: trivy-results.sarif

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
         with:
           languages: ${{ matrix.language }}
           build-mode: none
@@ -46,6 +46,6 @@ jobs:
         run: npm ci
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -42,6 +42,6 @@ jobs:
 
       - name: Upload Scorecard results to code scanning
         if: ${{ always() && hashFiles('scorecard-results.sarif') != '' }}
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
         with:
           sarif_file: scorecard-results.sarif


### PR DESCRIPTION
Combines Dependabot PRs #135, #136, and #137, which each bump one of the three `github/codeql-action` references (`init`, `analyze`, `upload-sarif`) from v4.36.2 to v4.36.3 independently.

Merging any one of those PRs alone breaks the `Analyze` job in `.github/workflows/codeql.yml`, because CodeQL requires the `init` and `analyze` steps in a job to run the same action version:

```
Loaded a configuration file for version '4.36.2', but running version '4.36.3'
```

This PR bumps all four references (`codeql.yml` init + analyze, `ci.yml` upload-sarif, `scorecard.yml` upload-sarif) to the same v4.36.3 SHA together, so the workflow stays consistent. Once merged, #135/#136/#137 will be closed as superseded.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PJyro83oZ4SGWgG8Xa7XtP)_