### PR TITLE
Update CodeQL action steps together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,7 @@ updates:
     labels:
       - dependencies
       - github-actions
+    groups:
+      codeql-action:
+        patterns:
+          - github/codeql-action/*

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
         with:
           languages: ${{ matrix.language }}
           build-mode: none
@@ -46,6 +46,6 @@ jobs:
         run: npm ci
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

- Updates `github/codeql-action/init` and `github/codeql-action/analyze` to the same v4.37.0 pinned SHA.
- Adds a Dependabot GitHub Actions group for `github/codeql-action/*` so related CodeQL action steps are proposed together next time.

## Why

Dependabot opened #142 and #143 separately. Each PR updates only one half of the CodeQL workflow pair, so the CodeQL job fails with a version mismatch between the initialized configuration and the analysis action.

Supersedes #142 and #143.

## Validation

- `npx prettier --check .github/dependabot.yml .github/workflows/codeql.yml`