### PR TITLE
Fix brace-expansion bypass advisory GHSA-rgw5-rvv9-x895

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1600,9 +1600,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
`npm audit --audit-level=high` (the `Dependency vulnerability gate` CI check) started failing again on #158 and #159, blocking both — same pattern as before, a new advisory disclosed against a package already on `master`:

- **`brace-expansion` 4.0.0-5.0.8** — GHSA-rgw5-rvv9-x895, a DoS via unbounded intermediate arrays that bypasses the mitigation for the earlier CVE-2026-14257 (which #156 already fixed by bumping to 5.0.8). Pulled in via `eslint@10.8.0` → `minimatch@10.2.5` → `brace-expansion`.

`npm audit fix` resolves it to `brace-expansion@5.0.9`, within `minimatch`'s existing semver range — no direct dependency bump needed. `npm run validate` passes clean.

Once merged, this should unblock #158 and #159.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PJyro83oZ4SGWgG8Xa7XtP)_