### PR TITLE
Fix nanoid infinite loop advisory GHSA-2v37-7h3g-55p8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2654,9 +2654,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
`npm audit --audit-level=high` (the `Dependency vulnerability gate` CI check) started failing again on #161 and #162 — same pattern as the last two audit-fix rounds (#156, #160), a new advisory disclosed against a package already on `master`:

- **`nanoid` <3.3.17** — GHSA-2v37-7h3g-55p8, custom generators can loop indefinitely when `size` is zero. Pulled in via `vitest@4.1.10` → `vite@8.0.16` → `postcss@8.5.23` → `nanoid`.

`npm audit fix` resolves it to `nanoid@3.3.18`, within `postcss`'s existing semver range — no direct dependency bump needed. `npm run validate` passes clean.

Once merged, this should unblock #161 and #162.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PJyro83oZ4SGWgG8Xa7XtP)_